### PR TITLE
Add Homebrew.jl/ImageMagick's bin directory to PATH

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -74,6 +74,7 @@ end
     function __init__()
         ENV["MAGICK_CONFIGURE_PATH"] = joinpath("$(Homebrew.prefix("imagemagick"))","lib","ImageMagick","config-Q16")
         ENV["MAGICK_CODER_MODULE_PATH"] = joinpath("$(Homebrew.prefix("imagemagick"))", "lib","ImageMagick","modules-Q16","coders")
+        ENV["PATH"] *= ":" * joinpath("$(Homebrew.prefix("imagemagick"))", "bin")
     end
     """ )
 end


### PR DESCRIPTION
This allows issues like https://github.com/timholy/Images.jl/issues/240 to work with `Homebrew.jl`.

Contents of bin directory on OSX 10.10 with ImageMagick 6.8.9:

```
Magick++-config
Magick-config
MagickCore-config
MagickWand-config
Wand-config
animate
compare
composite
conjure
convert
display
identify
import
mogrify
montage
stream
```