### PR TITLE
Update Windows binary URL, enable AppVeyor

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ An image processing library for [Julia](http://julialang.org/).
 
 [![Images](http://pkg.julialang.org/badges/Images_release.svg)](http://pkg.julialang.org/?pkg=Images&ver=release)
 [![Coverage Status](https://coveralls.io/repos/timholy/Images.jl/badge.png?branch=master)](https://coveralls.io/r/timholy/Images.jl?branch=master)
+[![Build status](https://ci.appveyor.com/api/projects/status/github/timholy/Images.jl?svg=true&branch=master)](https://ci.appveyor.com/project/timholy/images-jl/branch/master)
 
 ## Installation
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,18 @@
+environment:
+  matrix:
+  - JULIAVERSION: "x86/0.3/julia-0.3-latest-win32.exe"
+  - JULIAVERSION: "x64/0.3/julia-0.3-latest-win64.exe"
+
+install:
+# Download most recent Julia Windows binary
+  - ps: (new-object net.webclient).DownloadFile($("http://s3.amazonaws.com/julialang/bin/winnt/"+$env:JULIAVERSION), "C:\projects\julia-binary.exe")
+# Run installer silently, output to C:\projects\julia
+  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+
+build_script:
+# Need to convert from shallow to complete for Pkg.clone to work
+  - IF EXIST .git\shallow (git fetch --unshallow)
+  - C:\projects\julia\bin\julia -F -e "versioninfo(); Pkg.clone(pwd(), \"Images\"); Pkg.build(\"Images\")"
+
+test_script:
+  - C:\projects\julia\bin\julia -e "Pkg.test(\"Images\")"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,12 @@ environment:
   - JULIAVERSION: "x86/0.3/julia-0.3-latest-win32.exe"
   - JULIAVERSION: "x64/0.3/julia-0.3-latest-win64.exe"
 
+notifications:
+  - provider: Email
+    on_build_success: false
+    on_build_failure: false
+    on_build_status_changed: false
+
 install:
 # Download most recent Julia Windows binary
   - ps: (new-object net.webclient).DownloadFile($("http://s3.amazonaws.com/julialang/bin/winnt/"+$env:JULIAVERSION), "C:\projects\julia-binary.exe")

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -29,7 +29,7 @@ end
 
     # Will need to be updated for releases
     # TODO: checksums: we have gpg
-    magick_exe = "ImageMagick-6.9.0-0-Q16-$(OS_ARCH)-dll.exe"
+    magick_exe = "ImageMagick-6.9.0-3-Q16-$(OS_ARCH)-dll.exe"
 
     magick_tmpdir = BinDeps.downloadsdir(libwand)
     magick_url = "http://www.imagemagick.org/download/binaries/$(magick_exe)"

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -84,7 +84,7 @@ if isdefined(:__init__)
 end
 p = ccall((:MagickQueryConfigureOption, libwand), Ptr{Uint8}, (Ptr{Uint8},), "LIB_VERSION_NUMBER")
 vstr = string("v\"", join(split(bytestring(p), ',')[1:3], '.'), "\"")
-open("versioninfo.jl", "w") do file
+open(joinpath(dirname(@__FILE__),"versioninfo.jl"), "w") do file
     write(file, "const libversion = $vstr\n")
 end
 end


### PR DESCRIPTION
I can squash these if you'd prefer.

Might be good to turn on a nightly build of this too like we did for HDF5, as long as the queue's not getting too long on your AppVeyor account.

Results should be at https://ci.appveyor.com/project/tkelman/images-jl/build/1.0.4, will see