### PR TITLE
When imwrite is passed a file name with a .nhdr extension its behavior i...

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -590,7 +590,9 @@ add_image_file_format(".dummy", b"Dummy Image", Dummy, "dummy.jl")
 # NRRD image format
 type NRRDFile <: ImageFileType end
 add_image_file_format(".nrrd", b"NRRD", NRRDFile, "nrrd.jl")
-add_image_file_format(".nhdr", b"NRRD", NRRDFile, "nrrd.jl")
+# NRRD header only
+type NRRDHeader <: ImageFileType end
+add_image_file_format(".nhdr", b"NRRD", NRRDHeader, "nrrd.jl")
 
 # Andor Technologies SIF file format
 type AndorSIF <: Images.ImageFileType end


### PR DESCRIPTION
...s now different than when passed a name with a .nrrd extension.  .nhdr now only writes an nrrd header, and throws an error when the datafile property is not specified. When passing the .nhdr extension it is no longer necessary for the user to specify the headeronly property, and the props keyword arg is now set to img.properties by default.  When passed a .nrrd extension, imwrite behaves the same as before.

Note that this breaks at least one nrrd test in the Images test suite.  If you think these changes are good, I am happy to fix the broken test as well.