### PR TITLE
Fix LoadError with latest Julia

### DIFF
--- a/src/map.jl
+++ b/src/map.jl
@@ -265,7 +265,7 @@ for SI in (MapInfo, AbstractClamp)
             end
         end
         for OA in (:RGBA, :ARGB, :BGRA)
-            exAlphaGray = ST == MapNone ? : nothing : quote
+            exAlphaGray = ST == MapNone ? :nothing : quote
                 function map{T,S}(mapi::$ST{$OA{T}}, g::GrayAlpha{S})
                     x = map1(mapi, g.c.val)
                     $OA{T}(x,x,x,map1(mapi, g.alpha))


### PR DESCRIPTION
Since JuliaLang/julia@6e06078e1ba8ef517a89518c632ca96c3a704464 I get:
LoadError: syntax: space not allowed after ":" used for quoting

This fixes it so the package loads, but there are still a lot of deprecation warnings.