### PR TITLE
Minor change to remove deprecation warning.

### DIFF
--- a/src/ioformats/OSXnative.jl
+++ b/src/ioformats/OSXnative.jl
@@ -310,7 +310,7 @@ function CFStringGetCString(CFStringRef::Ptr{Void})
     res = ccall(:CFStringGetCString, Bool, (Ptr{Void}, Ptr{Uint8}, Uint, Uint16),
                 CFStringRef, buffer, length(buffer), 0x0600)
     res == C_NULL && return ""
-    return bytestring(convert(Ptr{Uint8}, buffer))
+    return bytestring(pointer(buffer))
 end
 
 # These were unsafe, can return null pointers at random times.


### PR DESCRIPTION
The warning was
```julia
WARNING: convert{T}(p::Type{Ptr{T}},a::Array) is deprecated, use convert(p,pointer(a)) instead.
```
However, it seems to me that using a pointer in the first place was probably unnecessary.  @rsrock, am I missing something?