### PR TITLE
Fixed ERROR: imresize_julia! not defined

### DIFF
--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -1037,7 +1037,7 @@ function imresize!(resized, original)
     resized
 end
 
-imresize(original, new_size) = imresize_julia!(similar(original, new_size), original)
+imresize(original, new_size) = imresize!(similar(original, new_size), original)
 
 convertsafely{T<:FloatingPoint}(::Type{T}, val) = convert(T, val)
 convertsafely{T<:Integer}(::Type{T}, val::Integer) = convert(T, val)

--- a/test/algorithms.jl
+++ b/test/algorithms.jl
@@ -322,3 +322,8 @@ P = [ 0.0  0.0  0.0   0.0   0.0   0.0   0.0  0.0;
 
 Q = Images.shepp_logan(8,highContrast=false)
 @test norm((P-Q)[:]) < 1e-10
+
+# image resize
+img = convert(Images.Image, zeros(10,10))
+img2 = Images.imresize(img, (5,5))
+@test length(img2) == 25


### PR DESCRIPTION
Call to imresize() resulted in ERROR: imresize_julia! not defined
Bug introduced in f203853c5b8dafc2115a1a7ba29a31ceeda18892
Initially function imresize was named imresize_julia (see https://groups.google.com/forum/#!msg/julia-users/wG1g9C7S6Mg/zx9Pqntv1e0J) to compare different imresize approaches