### PR TITLE
Adding raw() to get raw buffer behind an image

### DIFF
--- a/src/Images.jl
+++ b/src/Images.jl
@@ -154,6 +154,7 @@ export # types
     timedim,
     width,
     widthheight,
+    raw,
 
     # io functions
     add_image_file_format,

--- a/src/core.jl
+++ b/src/core.jl
@@ -201,6 +201,16 @@ function reinterpret{T,S}(::Type{T}, img::AbstractImageDirect{S})
     shareproperties(img, reinterpret(T, data(img)))
 end
 
+## To get data in raw format, and unwrap UfixedBase if present
+function raw(img::Image)
+    if eltype(eltype(data(img))) <: FixedPointNumbers.UfixedBase
+        reinterpret( FixedPointNumbers.rawtype(eltype(eltype(img))), data(img) )
+    else
+        data(img)
+    end
+end
+
+
 ## convert
 convert{T}(::Type{Image{T}}, img::Image{T}) = img
 convert(::Type{Image}, img::Image) = img

--- a/src/ioformats/nrrd.jl
+++ b/src/ioformats/nrrd.jl
@@ -292,7 +292,7 @@ function imwrite(img, sheader::IO, ::Type{Images.NRRDFile}; props::Dict = Dict{A
                                    (T == Float64) ? "double" :
                                    (T == Float16) ? "float16" :
                                    error("Can't write type $T"))
-    elseif T <: FixedPointNumbers.UfixedBase
+    elseif eltype(T) <: FixedPointNumbers.UfixedBase
         # we don't want to write something like "type: ufixedbase{uint8,8}", so fix it
         T = FixedPointNumbers.rawtype(eltype(eltype(img)))
         println(sheader, "type: ", lowercase(string(T)))


### PR DESCRIPTION
This adds the `raw(img)` functionality, as discussed in #190 
Should be merged after #293 