### PR TITLE
Don't clamp by default before writing (fixes #256)

### DIFF
--- a/doc/function_reference.md
+++ b/doc/function_reference.md
@@ -650,7 +650,15 @@ directly. Some writers take additional arguments, for example
 imwrite(img, "myimage.jpg", quality=80)
 ```
 
-to control the quality setting in JPEG compression.
+to control the quality setting in JPEG compression. Another useful keyword argument
+is `mapi`, which allows you apply a MapInfo transformation on the elements
+before writing. For example, if you have floating-point images whose values are
+sometimes out-of-bounds (smaller than 0 or bigger than 1), you can avoid an error
+upon writing with
+```{.julia execute="false"}
+imwrite(img, "myimage.png", mapi=mapinfo(Clamp, img))
+```
+and values will be clamped, as needed, before writing.
 
 ## loadformat
 ```{.julia execute="false"}

--- a/test/io.jl
+++ b/test/io.jl
@@ -107,3 +107,13 @@ fn = joinpath(workdir, "3d.tif")
 Images.imwrite(A, fn)
 B = Images.imread(fn)
 @test A == B
+
+# Clamping (issue #256)
+A = grayim(rand(2,2))
+A[1,1] = -0.4
+fn = joinpath(workdir, "2by2.png")
+@test_throws InexactError Images.imwrite(A, fn)
+Images.imwrite(A, fn, mapi=Images.mapinfo(Images.Clamp, A))
+B = Images.imread(fn)
+A[1,1] = 0
+@test B == map(Ufixed8, A)


### PR DESCRIPTION
Current, `imwrite` clamps values before writing, so that images that contain (for example) negative values get truncated at 0. This commit changes the behavior to throw an error, as argued in #256.
 
This also adds a new `mapinfo(Clamp, img)` to allow users to obtain the earlier behavior.

@rsrock, IIUC I don't need to do anything special to have the github.io documentation update, right?
