### PR TITLE
Fix two test failures related to precision

### DIFF
--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -321,6 +321,7 @@ difftype{CV<:AbstractRGB,T<:Real}(::Type{CV}, ::Type{T}) = RGB{Float32}
 difftype{CV<:AbstractRGB}(::Type{CV}, ::Type{Float64}) = RGB{Float64}
 
 accum{T<:Integer}(::Type{T}) = Int
+accum(::Type{Float32})    = Float32
 accum{T<:Real}(::Type{T}) = Float64
 
 # normalized by Array size

--- a/test/algorithms.jl
+++ b/test/algorithms.jl
@@ -182,7 +182,9 @@ facts("Algorithms") do
         Afft = Images.imfilter_fft(A, kern, "inner")
         @fact Af => roughly(Afft)
         h = [0.24,0.87]
-        @fact Images.imfilter(eye(3), h, "inner") => roughly(Images.imfilter_fft(eye(3), h, "inner"))  # issue #204
+        hfft = Images.imfilter_fft(eye(3), h, "inner")
+        hfft[abs(hfft) .< 3eps()] = 0
+        @fact Images.imfilter(eye(3), h, "inner") => roughly(hfft)  # issue #204
 
         @fact approx_equal(Images.imfilter_gaussian(ones(4,4), [5,5]), 1.0) => true
         A = fill(convert(Float32, NaN), 3, 3)


### PR DESCRIPTION
I'm a little more iffy on whether we want to accumulate to a `Float32` (the alternative being convert to `Float32` for the test), but on balance this seems to be the right thing to do.

The FFT test failure is due to https://github.com/JuliaLang/julia/pull/12393 (and easily fixed).