### PR TITLE
disable precompilation on windows

### DIFF
--- a/src/Images.jl
+++ b/src/Images.jl
@@ -1,4 +1,4 @@
-VERSION >= v"0.4.0-dev+6521" && __precompile__()
+VERSION >= v"0.4.0-dev+6521" && __precompile__(@unix? true : false)
 
 module Images
 


### PR DESCRIPTION
may help with the RegistryKeyLookupFailed `CoderModulesPath' error?