### PR TITLE
imwrite (ImageMagick): provide fallback for poorly-typed images

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -373,13 +373,12 @@ for ACV in (ColorValue, AbstractRGB,AbstractGray)
         (length(CV.parameters) == 1 && !(CV.abstract)) || continue
         CVnew = CV<:AbstractGray ? Gray : RGB
         @eval mapinfo{T<:Ufixed}(::Type{ImageMagick}, img::AbstractArray{$CV{T}}) = MapNone{$CVnew{T}}()
-        @eval mapinfo{T<:FloatingPoint}(::Type{ImageMagick}, img::AbstractArray{$CV{T}}) =
-            MapNone{$CVnew{Ufixed8}}()
+        @eval mapinfo{CV<:$CV}(::Type{ImageMagick}, img::AbstractArray{CV}) = MapNone{$CVnew{Ufixed8}}()
         CVnew = CV<:AbstractGray ? Gray : BGR
         for AC in subtypes(AbstractAlphaColorValue)
             (length(AC.parameters) == 2 && !(AC.abstract)) || continue
             @eval mapinfo{T<:Ufixed}(::Type{ImageMagick}, img::AbstractArray{$AC{$CV{T},T}}) = MapNone{$AC{$CVnew{T},T}}()
-            @eval mapinfo{T<:FloatingPoint}(::Type{ImageMagick}, img::AbstractArray{$AC{$CV{T},T}}) = MapNone{$AC{$CVnew{Ufixed8}, Ufixed8}}()
+            @eval mapinfo{CV<:$CV}(::Type{ImageMagick}, img::AbstractArray{$AC{CV}}) = MapNone{$AC{$CVnew{Ufixed8}, Ufixed8}}()
         end
     end
 end

--- a/test/io.jl
+++ b/test/io.jl
@@ -95,7 +95,11 @@ facts("IO") do
         cmaprgb[129:end] = [(1-x)*w + x*r for x in f[2:end]]
         img = Images.ImageCmap(dataint, cmaprgb)
         Images.imwrite(img,joinpath(workdir,"cmap.jpg"))
-        Images.imwrite(img,joinpath(workdir,"cmap.pbm"))  # issue #336
+        cmaprgb = Array(RGB, 255) # poorly-typed cmap, issue #336
+        cmaprgb[1:128] = [(1-x)*b + x*w for x in f]
+        cmaprgb[129:end] = [(1-x)*w + x*r for x in f[2:end]]
+        img = Images.ImageCmap(dataint, cmaprgb)
+        Images.imwrite(img,joinpath(workdir,"cmap.pbm"))
     end
 
     context("Alpha") do


### PR DESCRIPTION
Fixes #336. While using poorly-typed colormaps is a bad idea, the error was not helpful.