### PR TITLE
Revert "disable precompilation on windows"

### DIFF
--- a/src/Images.jl
+++ b/src/Images.jl
@@ -1,4 +1,4 @@
-VERSION >= v"0.4.0-dev+6521" && __precompile__(@unix? true : false)
+VERSION >= v"0.4.0-dev+6521" && __precompile__()
 
 module Images
 


### PR DESCRIPTION
This reverts commit e60ad4a18ff3010aef5f9ebb6111177510476fdf. With the merger
of julia#12638, this appears to be unnecessary. Ref #338.