### PR TITLE
Move MagickWandGenesis into the deps.jl file

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -15,11 +15,12 @@ aliases = vec(libnames.*transpose(suffixes).*reshape(options,(1,1,length(options
 libwand = library_dependency("libwand", aliases = aliases)
 
 @linux_only begin
-    provides(AptGet, "libmagickwand4", libwand)
-    provides(AptGet, "libmagickwand5", libwand)
-    provides(AptGet, "libmagickwand-6.q16-2", libwand)
-    provides(Pacman, "imagemagick", libwand)
-    provides(Yum, "ImageMagick", libwand)
+    kwargs = Any[(:onload, "ccall((:MagickWandGenesis,libwand), Void, ())")]
+    provides(AptGet, "libmagickwand4", libwand; kwargs...)
+    provides(AptGet, "libmagickwand5", libwand; kwargs...)
+    provides(AptGet, "libmagickwand-6.q16-2", libwand; kwargs...)
+    provides(Pacman, "imagemagick", libwand; kwargs...)
+    provides(Yum, "ImageMagick", libwand; kwargs...)
 end
 
 # TODO: remove me when upstream is fixed
@@ -62,7 +63,8 @@ end
             """
             ENV["MAGICK_CONFIGURE_PATH"] = \"$(escape_string(magick_libdir))\"
             ENV["MAGICK_CODER_MODULE_PATH"] = \"$(escape_string(magick_libdir))\"
-            """)
+            """,
+        onload = "ccall((:MagickWandGenesis,libwand), Void, ())")
 end
 
 @osx_only begin
@@ -76,6 +78,7 @@ end
         ENV["MAGICK_CONFIGURE_PATH"] = joinpath("$(Homebrew.prefix("imagemagick"))","lib","ImageMagick","config-Q16")
         ENV["MAGICK_CODER_MODULE_PATH"] = joinpath("$(Homebrew.prefix("imagemagick"))", "lib","ImageMagick","modules-Q16","coders")
         ENV["PATH"] = joinpath("$(Homebrew.prefix("imagemagick"))", "bin") * ":" * ENV["PATH"]
+        ccall((:MagickWandGenesis,libwand), Void, ())
     end
     """ )
 end

--- a/src/Images.jl
+++ b/src/Images.jl
@@ -46,8 +46,6 @@ include("algorithms.jl")
 include("connected.jl")
 include("edge.jl")
 
-__init__() = LibMagick.init()
-
 function precompile()
     for T in (Uint8, Uint16, Int, Float32, Float64)
         Tdiv = typeof(one(T)/2)

--- a/src/ioformats/libmagickwand.jl
+++ b/src/ioformats/libmagickwand.jl
@@ -33,14 +33,12 @@ end
 if isfile(versionfile)
     include(versionfile)
 end
+
 const have_imagemagick = isdefined(:libwand)
 
 # Initialize the library
-function init()
-    global libwand
-    if have_imagemagick
-        eval(:(ccall((:MagickWandGenesis, $libwand), Void, ())))
-    else
+function __init__()
+    if !have_imagemagick
         warn("ImageMagick utilities not found. Install for more file format support.")
     end
 end


### PR DESCRIPTION
Precompiled modules that use Images were getting this warning:
```
WARNING: eval from module LibMagick to RegisterMismatch:
Expr(:ccall, Expr(:tuple, :MagickWandGenesis, "/usr/lib/x86_64-linux-gnu/libMagickWand.so.5")::Any, :Void, Expr(:tuple)::Any)::Any
  ** incremental compilation may be broken for this module **
```
It seems to be a consequence of the conditional build logic. By moving this into the deps.jl file, we avoid the conditional logic.
