### PR TITLE
Allow imread(::Array, Images.ImageMagick) to read from array of bytes

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -257,7 +257,7 @@ imread(source, ::Type{OSXNative}) = LibOSXNative.imread(source)
 # fixed type for depths > 8
 const ufixedtype = @compat Dict(10=>Ufixed10, 12=>Ufixed12, 14=>Ufixed14, 16=>Ufixed16)
 
-@compat function imread(filename::Union{AbstractString,IO}, ::Type{ImageMagick};extraprop="",extrapropertynames=false)
+@compat function imread(filename::Union{AbstractString,IO,Array}, ::Type{ImageMagick};extraprop="",extrapropertynames=false)
     wand = LibMagick.MagickWand()
     LibMagick.readimage(wand, filename)
     LibMagick.resetiterator(wand)

--- a/src/io.jl
+++ b/src/io.jl
@@ -257,7 +257,7 @@ imread(source, ::Type{OSXNative}) = LibOSXNative.imread(source)
 # fixed type for depths > 8
 const ufixedtype = @compat Dict(10=>Ufixed10, 12=>Ufixed12, 14=>Ufixed14, 16=>Ufixed16)
 
-@compat function imread(filename::Union{AbstractString,IO,Array}, ::Type{ImageMagick};extraprop="",extrapropertynames=false)
+@compat function imread(filename::Union{AbstractString,IO,Vector{UInt8}}, ::Type{ImageMagick};extraprop="",extrapropertynames=false)
     wand = LibMagick.MagickWand()
     LibMagick.readimage(wand, filename)
     LibMagick.resetiterator(wand)

--- a/src/ioformats/libmagickwand.jl
+++ b/src/ioformats/libmagickwand.jl
@@ -231,6 +231,12 @@ function readimage(wand::MagickWand, stream::IO)
     nothing
 end
 
+function readimage(wand::MagickWand, stream::Array)
+    status = ccall((:MagickReadImageBlob, libwand), Cint, (Ptr{Void}, Ptr{Void}, Cint), wand.ptr, stream, length(stream)*sizeof(eltype(stream)))
+    status == 0 && error(wand)
+    nothing
+end
+
 function writeimage(wand::MagickWand, filename::AbstractString)
     status = ccall((:MagickWriteImages, libwand), Cint, (Ptr{Void}, Ptr{UInt8}, Cint), wand.ptr, filename, true)
     status == 0 && error(wand)

--- a/src/ioformats/libmagickwand.jl
+++ b/src/ioformats/libmagickwand.jl
@@ -231,7 +231,7 @@ function readimage(wand::MagickWand, stream::IO)
     nothing
 end
 
-function readimage(wand::MagickWand, stream::Array)
+function readimage(wand::MagickWand, stream::Vector{UInt8})
     status = ccall((:MagickReadImageBlob, libwand), Cint, (Ptr{Void}, Ptr{Void}, Cint), wand.ptr, stream, length(stream)*sizeof(eltype(stream)))
     status == 0 && error(wand)
     nothing

--- a/test/io.jl
+++ b/test/io.jl
@@ -139,4 +139,13 @@ facts("IO") do
         close(io)
         @fact isa(img, Images.Image) --> true
     end
+
+    @unix_only context("Reading from a byte array (issue #279)") do
+        fn = joinpath(workdir, "2by2.png")
+        io = open(fn)
+        arr = readbytes(io)
+        close(io)
+        img = Images.imread(arr, Images.ImageMagick)
+        @fact isa(img, Images.Image) --> true
+    end
 end


### PR DESCRIPTION
I came across issue #279 since I head the same problem so I implemented @timholy's suggested fix.  
The patch allows imread to accept an Array as well as String and IO - I'm not sure whether this is too general though, do you have any opinion on tightening it?