### PR TITLE
Workaround upstream weak type inference

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -11,7 +11,7 @@ type Image{T,N,A<:AbstractArray} <: AbstractImageDirect{T,N}
     data::A
     properties::Dict{ASCIIString,Any}
 end
-Image(data::AbstractArray, props::Dict) = Image{eltype(data),ndims(data),typeof(data)}(data,props)
+Image{T,N}(data::AbstractArray{T,N}, props::Dict) = Image{eltype(data),N,typeof(data)}(data,props)
 Image(data::AbstractArray; kwargs...) = Image(data, kwargs2dict(kwargs))
 
 # Indexed image (colormap)


### PR DESCRIPTION
Workaround https://github.com/JuliaLang/julia/issues/13082.
Trying to partially fix #356.