### PR TITLE
remove UFixed deprecations

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Let's begin by reading an image from a file:
 ```
 julia> img = imread("rose.png")
 RGB Image with:
-  data: 70x46 Array{RGB{UfixedBase{Uint8,8}},2}
+  data: 70x46 Array{RGB{UFixed{Uint8,8}},2}
   properties:
     IMcs: sRGB
     spatialorder:  x y
@@ -88,17 +88,17 @@ show(img)
 to see the output above.
 
 The first line tells you that this is an RGB image.
-It is stored as a two-dimensional `Array` of `RGB{UfixedBase{Uint8,8}}`.
+It is stored as a two-dimensional `Array` of `RGB{UFixed{Uint8,8}}`.
 To see what this pixel type is, we can do the following:
 ```
 julia> img[1,1]
-RGB{Ufixed8}(0.188,0.184,0.176)
+RGB{UFixed8}(0.188,0.184,0.176)
 ```
 This extracts the first pixel, the one visually at the upper-left of the image. You can see that
 an `RGB` (which comes from the [Colors](https://github.com/JuliaGraphics/Colors.jl) package) is a triple of values.
-The `Ufixed8` number type (which comes from the
+The `UFixed8` number type (which comes from the
 [FixedPointNumbers](https://github.com/JeffBezanson/FixedPointNumbers.jl) package), and whose long
-name is `UfixedBase{Uint8,8}`)
+name is `UFixed{Uint8,8}`)
 represents fractional numbers, those that can encode values that lie between 0 and 1, using just 1 byte (8 bits).
 If you've previously used other image processing libraries, you may be used to thinking of two basic
 image types, floating point-valued and integer-valued. In those libraries, "saturated"
@@ -106,7 +106,7 @@ image types, floating point-valued and integer-valued. In those libraries, "satu
 represented by `1.0` for floating point-valued images, 255 for a `Uint8` image,
 and `0x0fff` for an image collected by a 12-bit camera.
 `Images.jl`, via Colors and FixedPointNumbers, unifies these so that `1` always means saturated, no
-matter whether the element type is `Float64`, `Ufixed8`, or `Ufixed12`.
+matter whether the element type is `Float64`, `UFixed8`, or `UFixed12`.
 This makes it easier to write generic algorithms and visualization code,
 while still allowing one to use efficient (and C-compatible) raw representations.
 
@@ -163,7 +163,7 @@ Of course, if you prefer to work with plain arrays, you can convert it:
 julia> imA = convert(Array, img);
 
 julia> summary(imA)
-"46x70 Array{RGB{UfixedBase{Uint8,8}},2}"
+"46x70 Array{RGB{UFixed{Uint8,8}},2}"
 ```
 You can see that this permuted the dimensions into vertical-major order, consistent
 with the column-major order with which Julia stores `Arrays`. Note that this
@@ -173,7 +173,7 @@ If you prefer to extract into an array of plain numbers in color-last order
 ```
 julia> imsep = separate(img)
 RGB Image with:
-  data: 46x70x3 Array{UfixedBase{Uint8,8},3}
+  data: 46x70x3 Array{UFixed{Uint8,8},3}
   properties:
     IMcs: sRGB
     colorspace: RGB
@@ -187,9 +187,9 @@ is used to encode color, and `"colorspace"` so you know how to interpret these c
 
 Compare this to
 ```
-julia> imr = reinterpret(Ufixed8, img)
+julia> imr = reinterpret(UFixed8, img)
 RGB Image with:
-  data: 3x70x46 Array{UfixedBase{Uint8,8},3}
+  data: 3x70x46 Array{UFixed{Uint8,8},3}
   properties:
     IMcs: sRGB
     colorspace: RGB
@@ -205,7 +205,7 @@ You can go back to using Colors to encode your image this way:
 ```
 julia> imcomb = convert(Image{RGB}, imsep)
 RGB Image with:
-  data: 46x70 Array{RGB{UfixedBase{Uint8,8}},2}
+  data: 46x70 Array{RGB{UFixed{Uint8,8}},2}
   properties:
     IMcs: sRGB
     spatialorder:  y x
@@ -245,7 +245,7 @@ Of course, you can combine these commands, for example
 ```julia
 A = reinterpret(Uint8, data(img))
 ```
-will, for a `RGB{Ufixed8}` image, return a raw 3d array.
+will, for a `RGB{UFixed8}` image, return a raw 3d array.
 This can be useful if you want to interact with external code (a C-library, for example).
 Assuming you don't want to lose orientation information, you can wrap a returned array `B`
 as `shareproperties(img, B)`.

--- a/REQUIRE
+++ b/REQUIRE
@@ -6,3 +6,4 @@ SIUnits
 Zlib
 Graphics 0.1
 FileIO
+

--- a/doc/function_reference.md
+++ b/doc/function_reference.md
@@ -153,7 +153,7 @@ access is desired. For example
 
 ```{.julia execute="false"}
 img = imread("someimage.tif")
-typeof( data(img) )  # returns array with element type UfixedBase{Uint8,8}
+typeof( data(img) )  # returns array with element type UFixed{Uint8,8}
 typeof( raw(img) )   # returns array with element type Uint8
 
 ```
@@ -549,7 +549,7 @@ Here is how to directly construct the major concrete `MapInfo` types:
 
 - `ScaleSigned(T, scalefactor)` multiplies the image by the scalefactor, then
   clamps to the range `[-1,1]`. If `T` is a floating-point type, it stays in
-  this representation.  If `T` is `RGB24` or `RGB{Ufixed8}`, then it is encoded
+  this representation.  If `T` is `RGB24` or `RGB{UFixed8}`, then it is encoded
   as a magenta (positive)/green (negative) image.
 
 There are also convenience functions:

--- a/doc/index.md
+++ b/doc/index.md
@@ -83,7 +83,7 @@ Let's begin by reading an image from a file:
 ```{.julia execute="false"}
 julia> img = imread("rose.png")
 RGB Image with:
-  data: 70x46 Array{RGB{UfixedBase{Uint8,8}},2}
+  data: 70x46 Array{RGB{UFixed{Uint8,8}},2}
   properties:
     IMcs: sRGB
     spatialorder:  x y
@@ -102,20 +102,20 @@ show(img)
 to see the output above.
 
 The first line tells you that this is an RGB image.
-It is stored as a two-dimensional `Array` of `RGB{UfixedBase{Uint8,8}}`.
+It is stored as a two-dimensional `Array` of `RGB{UFixed{Uint8,8}}`.
 To see what this pixel type is, we can do the following:
 
 ```{.julia execute="false"}
 julia> img[1,1]
-RGB{Ufixed8}(0.188,0.184,0.176)
+RGB{UFixed8}(0.188,0.184,0.176)
 ```
 
 This extracts the first pixel, the one visually at the upper-left of the
 image. You can see that an `RGB` (which comes from the
 [Colors](https://github.com/JuliaGraphics/Colors.jl) package) is a triple of values.
-The `Ufixed8` number type (which comes from the
+The `UFixed8` number type (which comes from the
 [FixedPointNumbers](https://github.com/JeffBezanson/FixedPointNumbers.jl)
-package), and whose long name is `UfixedBase{Uint8,8}`) represents fractional
+package), and whose long name is `UFixed{Uint8,8}`) represents fractional
 numbers, those that can encode values that lie between 0 and 1, using just 1
 byte (8 bits).  If you've previously used other image processing libraries, you
 may be used to thinking of two basic image types, floating point-valued and
@@ -123,8 +123,8 @@ integer-valued. In those libraries, "saturated" (the color white for an RGB
 image) would be represented by `1.0` for floating point-valued images, 255 for a
 `Uint8` image, and `0x0fff` for an image collected by a 12-bit camera.
 `Images.jl`, via Colors and FixedPointNumbers, unifies these so that `1` always
-means saturated, no matter whether the element type is `Float64`, `Ufixed8`, or
-`Ufixed12`.  This makes it easier to write generic algorithms and visualization
+means saturated, no matter whether the element type is `Float64`, `UFixed8`, or
+`UFixed12`.  This makes it easier to write generic algorithms and visualization
 code, while still allowing one to use efficient (and C-compatible) raw
 representations.
 
@@ -188,7 +188,7 @@ Of course, if you prefer to work with plain arrays, you can convert it:
 julia> imA = convert(Array, img);
 
 julia> summary(imA)
-"46x70 Array{RGB{UfixedBase{Uint8,8}},2}"
+"46x70 Array{RGB{UFixed{Uint8,8}},2}"
 ```
 
 You can see that this permuted the dimensions into vertical-major order,
@@ -200,7 +200,7 @@ Matlab), you can use
 ```{.julia execute="false"}
 julia> imsep = separate(img)
 RGB Image with:
-  data: 46x70x3 Array{UfixedBase{Uint8,8},3}
+  data: 46x70x3 Array{UFixed{Uint8,8},3}
   properties:
     IMcs: sRGB
     colorspace: RGB
@@ -217,9 +217,9 @@ how to interpret these colors.
 Compare this to
 
 ```{.julia execute="false"}
-julia> imr = reinterpret(Ufixed8, img)
+julia> imr = reinterpret(UFixed8, img)
 RGB Image with:
-  data: 3x70x46 Array{UfixedBase{Uint8,8},3}
+  data: 3x70x46 Array{UFixed{Uint8,8},3}
   properties:
     IMcs: sRGB
     colorspace: RGB
@@ -237,7 +237,7 @@ You can go back to using Colors to encode your image this way:
 ```{.julia execute="false"}
 julia> imcomb = convert(Image{RGB}, imsep)
 RGB Image with:
-  data: 46x70 Array{RGB{UfixedBase{Uint8,8}},2}
+  data: 46x70 Array{RGB{UFixed{Uint8,8}},2}
   properties:
     IMcs: sRGB
     spatialorder:  y x
@@ -288,7 +288,7 @@ Of course, you can combine these commands, for example
 A = reinterpret(Uint8, data(img))
 ```
 
-will, for a `RGB{Ufixed8}` image, return a raw 3d array.  This can be useful if
+will, for a `RGB{UFixed8}` image, return a raw 3d array.  This can be useful if
 you want to interact with external code (a C-library, for example).  Assuming
 you don't want to lose orientation information, you can wrap a returned array
 `B` as `shareproperties(img, B)`.

--- a/src/Images.jl
+++ b/src/Images.jl
@@ -253,13 +253,13 @@ import Base: scale, scale!  # delete when deprecations are removed
 @deprecate float32sc    float32
 @deprecate float64sc    float64
 @deprecate uint8sc      ufixed8sc
-@deprecate uint16sc(img)  ufixedsc(Ufixed16, img)
+@deprecate uint16sc(img)  ufixedsc(UFixed16, img)
 @deprecate ClipMin      ClampMin
 @deprecate ClipMax      ClampMax
 @deprecate ClipMinMax   ClampMinMax
 @deprecate climdefault(img) zero(eltype(img)), one(eltype(img))
-@deprecate ScaleMinMax{T<:Real}(img::AbstractArray{T}, mn, mx) ScaleMinMax(Ufixed8, img, mn, mx)
-@deprecate ScaleMinMax{T<:Color}(img::AbstractArray{T}, mn, mx) ScaleMinMax(RGB{Ufixed8}, img, mn, mx)
+@deprecate ScaleMinMax{T<:Real}(img::AbstractArray{T}, mn, mx) ScaleMinMax(UFixed8, img, mn, mx)
+@deprecate ScaleMinMax{T<:Color}(img::AbstractArray{T}, mn, mx) ScaleMinMax(RGB{UFixed8}, img, mn, mx)
 @deprecate scaleinfo    mapinfo
 @deprecate scale(mapi::MapInfo, A) map(mapi, A)                # delete imports above when eliminated
 @deprecate scale!(dest, mapi::MapInfo, A) map!(mapi, dest, A)  #   "

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -643,7 +643,7 @@ function imfilter_gaussian{T<:AbstractFloat}(img::AbstractArray{T}, sigma::Vecto
 end
 
 # For these types, you can't have NaNs
-@compat function imfilter_gaussian{T<:Union{Integer,Ufixed},TF<:AbstractFloat}(img::AbstractArray{T}, sigma::Vector; emit_warning = true, astype::Type{TF}=Float64)
+@compat function imfilter_gaussian{T<:Union{Integer,UFixed},TF<:AbstractFloat}(img::AbstractArray{T}, sigma::Vector; emit_warning = true, astype::Type{TF}=Float64)
     A = convert(Array{TF}, data(img))
     if all(sigma .== 0)
         return shareproperties(img, A)

--- a/src/core.jl
+++ b/src/core.jl
@@ -25,10 +25,10 @@ ImageCmap(data::AbstractArray, cmap::AbstractVector; kwargs...) = ImageCmap(data
 
 # Convenience constructors
 grayim(A::AbstractImage) = A
-grayim(A::AbstractArray{UInt8,2})  = grayim(reinterpret(Ufixed8, A))
-grayim(A::AbstractArray{UInt16,2}) = grayim(reinterpret(Ufixed16, A))
-grayim(A::AbstractArray{UInt8,3})  = grayim(reinterpret(Ufixed8, A))
-grayim(A::AbstractArray{UInt16,3}) = grayim(reinterpret(Ufixed16, A))
+grayim(A::AbstractArray{UInt8,2})  = grayim(reinterpret(UFixed8, A))
+grayim(A::AbstractArray{UInt16,2}) = grayim(reinterpret(UFixed16, A))
+grayim(A::AbstractArray{UInt8,3})  = grayim(reinterpret(UFixed8, A))
+grayim(A::AbstractArray{UInt16,3}) = grayim(reinterpret(UFixed16, A))
 grayim{T}(A::AbstractArray{T,2}) = Image(A; colorspace="Gray", spatialorder=["x","y"])
 grayim{T}(A::AbstractArray{T,3}) = Image(A; colorspace="Gray", spatialorder=["x","y","z"])
 
@@ -58,10 +58,10 @@ function colorim{T}(A::AbstractArray{T,3}, colorspace)
     end
 end
 
-colorim(A::AbstractArray{UInt8,3})  = colorim(reinterpret(Ufixed8, A))
-colorim(A::AbstractArray{UInt16,3}) = colorim(reinterpret(Ufixed16, A))
-colorim(A::AbstractArray{UInt8,3},  colorspace) = colorim(reinterpret(Ufixed8, A), colorspace)
-colorim(A::AbstractArray{UInt16,3}, colorspace) = colorim(reinterpret(Ufixed16, A), colorspace)
+colorim(A::AbstractArray{UInt8,3})  = colorim(reinterpret(UFixed8, A))
+colorim(A::AbstractArray{UInt16,3}) = colorim(reinterpret(UFixed16, A))
+colorim(A::AbstractArray{UInt8,3},  colorspace) = colorim(reinterpret(UFixed8, A), colorspace)
+colorim(A::AbstractArray{UInt16,3}, colorspace) = colorim(reinterpret(UFixed16, A), colorspace)
 
 
 #### Core operations ####
@@ -170,7 +170,7 @@ end
 ## reinterpret: T->Color
 # We have to distinguish two forms of call:
 #   form 1: reinterpret(RGB, img)
-#   form 2: reinterpret(RGB{Ufixed8}, img)
+#   form 2: reinterpret(RGB{UFixed8}, img)
 # Arrays
 reinterpret{T,CV<:Colorant}(::Type{CV}, A::Array{T,1}) = _reinterpret(CV, eltype(CV), A)
 reinterpret{T,CV<:Colorant}(::Type{CV}, A::Array{T})   = _reinterpret(CV, eltype(CV), A)
@@ -207,13 +207,13 @@ function reinterpret{T,S}(::Type{T}, img::AbstractImageDirect{S})
     shareproperties(img, reinterpret(T, data(img)))
 end
 
-## To get data in raw format, and unwrap UfixedBase if present
+## To get data in raw format, and unwrap UFixed if present
 function raw(img::AbstractArray)
     elemType = eltype(eltype(data(img)))
 
     @compat if (elemType <: Union{})  # weird fallback case
         data(img)
-    elseif eltype(eltype(data(img))) <: FixedPointNumbers.UfixedBase
+    elseif eltype(eltype(data(img))) <: FixedPointNumbers.UFixed
         reinterpret( FixedPointNumbers.rawtype(eltype(eltype(img))), data(img) )
     else
         data(img)

--- a/src/map.jl
+++ b/src/map.jl
@@ -1,7 +1,7 @@
 #### Elementwise manipulations (scaling/clamping/type conversion) ####
 
 # This file exists primarily to handle conversions for display and
-# saving to disk. Both of these operations require Ufixed-valued
+# saving to disk. Both of these operations require UFixed-valued
 # elements, but with display we always want to convert to 8-bit
 # whereas saving can handle 16-bit.
 # We also can't trust that user images are clamped properly.
@@ -39,7 +39,7 @@ similar{T}(mapi::MapNone, ::Type{T}, ::Type) = MapNone{T}()
 # Implementation
 @compat map{T}(mapi::MapNone{T}, val::Union{Number,Colorant}) = convert(T, val)
 @compat map1(mapi::Union{MapNone{RGB24}, MapNone{ARGB32}}, b::Bool) = ifelse(b, 0xffuf8, 0x00uf8)
-@compat map1(mapi::Union{MapNone{RGB24},MapNone{ARGB32}}, val::Fractional) = convert(Ufixed8, val)
+@compat map1(mapi::Union{MapNone{RGB24},MapNone{ARGB32}}, val::Fractional) = convert(UFixed8, val)
 map1{CT<:Colorant}(mapi::MapNone{CT}, val::Fractional) = convert(eltype(CT), val)
 
 map{T<:Colorant}(mapi::MapNone{T}, img::AbstractImageIndexed{T}) = convert(Image{T}, img)
@@ -59,12 +59,12 @@ similar{S,T,N}(mapi::BitShift{S,N}, ::Type{T}, ::Type) = BitShift{T,N}()
 # Implementation
 immutable BS{N} end
 _map{T<:Unsigned,N}(::Type{T}, ::Type{BS{N}}, val::Unsigned) = (v = val>>>N; tm = oftype(val, typemax(T)); convert(T, ifelse(v > tm, tm, v)))
-_map{T<:Ufixed,N}(::Type{T}, ::Type{BS{N}}, val::Ufixed) = reinterpret(T, _map(FixedPointNumbers.rawtype(T), BS{N}, reinterpret(val)))
+_map{T<:UFixed,N}(::Type{T}, ::Type{BS{N}}, val::UFixed) = reinterpret(T, _map(FixedPointNumbers.rawtype(T), BS{N}, reinterpret(val)))
 map{T<:Real,N}(mapi::BitShift{T,N}, val::Real) = _map(T, BS{N}, val)
 map{T<:Real,N}(mapi::BitShift{Gray{T},N}, val::Gray) = Gray(_map(T, BS{N}, val.val))
 @compat map1{N}(mapi::Union{BitShift{RGB24,N},BitShift{ARGB32,N}}, val::Unsigned) = _map(UInt8, BS{N}, val)
-@compat map1{N}(mapi::Union{BitShift{RGB24,N},BitShift{ARGB32,N}}, val::Ufixed) = _map(Ufixed8, BS{N}, val)
-map1{CT<:Colorant,N}(mapi::BitShift{CT,N}, val::Ufixed) = _map(eltype(CT), BS{N}, val)
+@compat map1{N}(mapi::Union{BitShift{RGB24,N},BitShift{ARGB32,N}}, val::UFixed) = _map(UFixed8, BS{N}, val)
+map1{CT<:Colorant,N}(mapi::BitShift{CT,N}, val::UFixed) = _map(eltype(CT), BS{N}, val)
 
 
 ## Clamp types
@@ -109,9 +109,9 @@ map{T<:Fractional,F<:Fractional}(mapi::ClampMinMax{Gray{T},F}, val::Gray{F}) = c
 map{T<:Fractional,F<:Fractional}(mapi::ClampMin{Gray{T},Gray{F}}, val::Gray{F}) = convert(Gray{T}, max(val, mapi.min))
 map{T<:Fractional,F<:Fractional}(mapi::ClampMax{Gray{T},Gray{F}}, val::Gray{F}) = convert(Gray{T}, min(val, mapi.max))
 map{T<:Fractional,F<:Fractional}(mapi::ClampMinMax{Gray{T},Gray{F}}, val::Gray{F}) = convert(Gray{T},min(max(val, mapi.min), mapi.max))
-@compat map1{T<:Union{RGB24,ARGB32},F<:Fractional}(mapi::ClampMin{T,F}, val::F) = convert(Ufixed8, max(val, mapi.min))
-@compat map1{T<:Union{RGB24,ARGB32},F<:Fractional}(mapi::ClampMax{T,F}, val::F) = convert(Ufixed8, min(val, mapi.max))
-@compat map1{T<:Union{RGB24,ARGB32},F<:Fractional}(mapi::ClampMinMax{T,F}, val::F) = convert(Ufixed8,min(max(val, mapi.min), mapi.max))
+@compat map1{T<:Union{RGB24,ARGB32},F<:Fractional}(mapi::ClampMin{T,F}, val::F) = convert(UFixed8, max(val, mapi.min))
+@compat map1{T<:Union{RGB24,ARGB32},F<:Fractional}(mapi::ClampMax{T,F}, val::F) = convert(UFixed8, min(val, mapi.max))
+@compat map1{T<:Union{RGB24,ARGB32},F<:Fractional}(mapi::ClampMinMax{T,F}, val::F) = convert(UFixed8,min(max(val, mapi.min), mapi.max))
 map1{CT<:Colorant,F<:Fractional}(mapi::ClampMin{CT,F}, val::F) = convert(eltype(CT), max(val, mapi.min))
 map1{CT<:Colorant,F<:Fractional}(mapi::ClampMax{CT,F}, val::F) = convert(eltype(CT), min(val, mapi.max))
 map1{CT<:Colorant,F<:Fractional}(mapi::ClampMinMax{CT,F}, val::F) = convert(eltype(CT), min(max(val, mapi.min), mapi.max))
@@ -172,7 +172,7 @@ end
 end
 @compat function map1{To<:Union{RGB24,ARGB32},From<:Real}(mapi::ScaleMinMax{To,From}, val::From)
     t = ifelse(val  < mapi.min, zero(From), ifelse(val  > mapi.max, mapi.max-mapi.min, val -mapi.min))
-    convert(Ufixed8, mapi.s*t)
+    convert(UFixed8, mapi.s*t)
 end
 function map1{To<:Colorant,From<:Real}(mapi::ScaleMinMax{To,From}, val::From)
     t = ifelse(val  < mapi.min, zero(From), ifelse(val  > mapi.max, mapi.max-mapi.min, val -mapi.min))
@@ -200,10 +200,10 @@ ScaleSigned(img::AbstractArray) = ScaleSigned(Float32, img)
 similar{T,To,S}(mapi::ScaleSigned{To,S}, ::Type{T}, ::Type) = ScaleSigned{T,S}(mapi.s)
 
 map{T}(mapi::ScaleSigned{T}, val::Real) = convert(T, clamppm(mapi.s*val))
-@compat function map{C<:Union{RGB24, RGB{Ufixed8}}}(mapi::ScaleSigned{C}, val::Real)
+@compat function map{C<:Union{RGB24, RGB{UFixed8}}}(mapi::ScaleSigned{C}, val::Real)
     x = clamppm(mapi.s*val)
-    g = Ufixed8(abs(x))
-    ifelse(x >= 0, C(g, zero(Ufixed8), g), C(zero(Ufixed8), g, zero(Ufixed8)))
+    g = UFixed8(abs(x))
+    ifelse(x >= 0, C(g, zero(UFixed8), g), C(zero(UFixed8), g, zero(UFixed8)))
 end
 
 clamppm(x::Real) = ifelse(x >= 0, min(x, one(x)), max(x, -one(x)))
@@ -213,7 +213,7 @@ clamppm(x::Real) = ifelse(x >= 0, min(x, one(x)), max(x, -one(x)))
 
 immutable ScaleAutoMinMax{T} <: MapInfo{T} end
 ScaleAutoMinMax{T}(::Type{T}) = ScaleAutoMinMax{T}()
-ScaleAutoMinMax() = ScaleAutoMinMax{Ufixed8}()
+ScaleAutoMinMax() = ScaleAutoMinMax{UFixed8}()
 
 similar{T}(mapi::ScaleAutoMinMax, ::Type{T}, ::Type) = ScaleAutoMinMax{T}()
 
@@ -228,11 +228,11 @@ for SI in (MapInfo, AbstractClamp)
         @eval begin
             # Grayscale and GrayAlpha inputs
             map(mapi::$ST{RGB24}, g::Gray) = map(mapi, g.val)
-            map(mapi::$ST{RGB24}, g::Real) = (x = map1(mapi, g); convert(RGB24, RGB{Ufixed8}(x,x,x)))
+            map(mapi::$ST{RGB24}, g::Real) = (x = map1(mapi, g); convert(RGB24, RGB{UFixed8}(x,x,x)))
             function map(mapi::$ST{RGB24}, g::AbstractFloat)
                 if isfinite(g)
                     x = map1(mapi, g)
-                    convert(RGB24, RGB{Ufixed8}(x,x,x))
+                    convert(RGB24, RGB{UFixed8}(x,x,x))
                 else
                     RGB24(0)
                 end
@@ -241,11 +241,11 @@ for SI in (MapInfo, AbstractClamp)
             map(mapi::$ST{ARGB32}, g::Gray) = map(mapi, g.val)
             function map(mapi::$ST{ARGB32}, g::Real)
                 x = map1(mapi, g)
-                convert(ARGB32, ARGB{Ufixed8}(x,x,x,0xffuf8))
+                convert(ARGB32, ARGB{UFixed8}(x,x,x,0xffuf8))
             end
             function map{G<:Gray}(mapi::$ST{ARGB32}, g::TransparentColor{G})
                 x = map1(mapi, gray(g))
-                convert(ARGB32, ARGB{Ufixed8}(x,x,x,map1(mapi, g.alpha)))
+                convert(ARGB32, ARGB{UFixed8}(x,x,x,map1(mapi, g.alpha)))
             end
         end
         for O in (:RGB, :BGR)
@@ -276,15 +276,15 @@ for SI in (MapInfo, AbstractClamp)
         @eval begin
             # AbstractRGB and abstract ARGB inputs
             map(mapi::$ST{RGB24}, rgb::AbstractRGB) =
-                convert(RGB24, RGB{Ufixed8}(map1(mapi, red(rgb)), map1(mapi, green(rgb)), map1(mapi, blue(rgb))))
+                convert(RGB24, RGB{UFixed8}(map1(mapi, red(rgb)), map1(mapi, green(rgb)), map1(mapi, blue(rgb))))
             map{C<:AbstractRGB, TC}(mapi::$ST{RGB24}, argb::TransparentColor{C,TC}) =
-                convert(RGB24, RGB{Ufixed8}(map1(mapi, red(argb)), map1(mapi, green(argb)),
+                convert(RGB24, RGB{UFixed8}(map1(mapi, red(argb)), map1(mapi, green(argb)),
                                             map1(mapi, blue(argb))))
             map{C<:AbstractRGB, TC}(mapi::$ST{ARGB32}, argb::TransparentColor{C,TC}) =
-                convert(ARGB32, ARGB{Ufixed8}(map1(mapi, red(argb)), map1(mapi, green(argb)),
+                convert(ARGB32, ARGB{UFixed8}(map1(mapi, red(argb)), map1(mapi, green(argb)),
                                               map1(mapi, blue(argb)), map1(mapi, alpha(argb))))
             map(mapi::$ST{ARGB32}, rgb::AbstractRGB) =
-                convert(ARGB32, ARGB{Ufixed8}(map1(mapi, red(rgb)), map1(mapi, green(rgb)), map1(mapi, blue(rgb))))
+                convert(ARGB32, ARGB{UFixed8}(map1(mapi, red(rgb)), map1(mapi, green(rgb)), map1(mapi, blue(rgb))))
         end
         for O in (:RGB, :BGR)
             @eval begin
@@ -299,10 +299,10 @@ for SI in (MapInfo, AbstractClamp)
                 map{T, C<:AbstractRGB, TC}(mapi::$ST{$OA{T}}, argb::TransparentColor{C,TC}) =
                     $OA{T}(map1(mapi, red(argb)), map1(mapi, green(argb)),
                             map1(mapi, blue(argb)), map1(mapi, alpha(argb)))
-                map{T}(mapi::$ST{$OA{T}}, argb::ARGB32) = map(mapi, convert(RGBA{Ufixed8}, argb))
+                map{T}(mapi::$ST{$OA{T}}, argb::ARGB32) = map(mapi, convert(RGBA{UFixed8}, argb))
                 map{T}(mapi::$ST{$OA{T}}, rgb::AbstractRGB) =
                     $OA{T}(map1(mapi, red(rgb)), map1(mapi, green(rgb)), map1(mapi, blue(rgb)))
-                map{T}(mapi::$ST{$OA{T}}, rgb::RGB24) = map(mapi, convert(RGB{Ufixed8}, argb))
+                map{T}(mapi::$ST{$OA{T}}, rgb::RGB24) = map(mapi, convert(RGB{UFixed8}, argb))
             end
         end
     end
@@ -398,29 +398,29 @@ end
 
 
 #### MapInfo defaults
-# Each "client" can define its own methods. "clients" include Ufixed, RGB24/ARGB32, and ImageMagick
+# Each "client" can define its own methods. "clients" include UFixed, RGB24/ARGB32, and ImageMagick
 
-const bitshiftto8 = ((Ufixed10, 2), (Ufixed12, 4), (Ufixed14, 6), (Ufixed16, 8))
+const bitshiftto8 = ((UFixed10, 2), (UFixed12, 4), (UFixed14, 6), (UFixed16, 8))
 
 # typealias GrayType{T<:Fractional} Union{T, Gray{T}}
 @compat typealias GrayArray{T<:Fractional} Union{AbstractArray{T}, AbstractArray{Gray{T}}}
 # note, though, that we need to override for AbstractImage in case the "colorspace" property is defined differently
 
 # mapinfo{T<:Union{Real,Colorant}}(::Type{T}, img::AbstractArray{T}) = MapNone(img)
-mapinfo{T<:Ufixed}(::Type{T}, img::AbstractArray{T}) = MapNone(img)
+mapinfo{T<:UFixed}(::Type{T}, img::AbstractArray{T}) = MapNone(img)
 mapinfo{T<:AbstractFloat}(::Type{T}, img::AbstractArray{T}) = MapNone(img)
 
 # Grayscale methods
-mapinfo(::Type{Ufixed8}, img::GrayArray{Ufixed8}) = MapNone{Ufixed8}()
-mapinfo(::Type{Gray{Ufixed8}}, img::GrayArray{Ufixed8}) = MapNone{Gray{Ufixed8}}()
-mapinfo(::Type{GrayA{Ufixed8}}, img::AbstractArray{GrayA{Ufixed8}}) = MapNone{GrayA{Ufixed8}}()
+mapinfo(::Type{UFixed8}, img::GrayArray{UFixed8}) = MapNone{UFixed8}()
+mapinfo(::Type{Gray{UFixed8}}, img::GrayArray{UFixed8}) = MapNone{Gray{UFixed8}}()
+mapinfo(::Type{GrayA{UFixed8}}, img::AbstractArray{GrayA{UFixed8}}) = MapNone{GrayA{UFixed8}}()
 for (T,n) in bitshiftto8
-    @eval mapinfo(::Type{Ufixed8}, img::GrayArray{$T}) = BitShift{Ufixed8,$n}()
-    @eval mapinfo(::Type{Gray{Ufixed8}}, img::GrayArray{$T}) = BitShift{Gray{Ufixed8},$n}()
-    @eval mapinfo(::Type{GrayA{Ufixed8}}, img::AbstractArray{GrayA{$T}}) = BitShift{GrayA{Ufixed8},$n}()
+    @eval mapinfo(::Type{UFixed8}, img::GrayArray{$T}) = BitShift{UFixed8,$n}()
+    @eval mapinfo(::Type{Gray{UFixed8}}, img::GrayArray{$T}) = BitShift{Gray{UFixed8},$n}()
+    @eval mapinfo(::Type{GrayA{UFixed8}}, img::AbstractArray{GrayA{$T}}) = BitShift{GrayA{UFixed8},$n}()
 end
-mapinfo{T<:Ufixed,F<:AbstractFloat}(::Type{T}, img::GrayArray{F}) = ClampMinMax(T, zero(F), one(F))
-mapinfo{T<:Ufixed,F<:AbstractFloat}(::Type{Gray{T}}, img::GrayArray{F}) = ClampMinMax(Gray{T}, zero(F), one(F))
+mapinfo{T<:UFixed,F<:AbstractFloat}(::Type{T}, img::GrayArray{F}) = ClampMinMax(T, zero(F), one(F))
+mapinfo{T<:UFixed,F<:AbstractFloat}(::Type{Gray{T}}, img::GrayArray{F}) = ClampMinMax(Gray{T}, zero(F), one(F))
 mapinfo{T<:AbstractFloat, R<:Real}(::Type{T}, img::AbstractArray{R}) = MapNone(T)
 
 @compat mapinfo(::Type{RGB24}, img::Union{AbstractArray{Bool}, BitArray}) = MapNone{RGB24}()
@@ -429,14 +429,14 @@ mapinfo{F<:Fractional}(::Type{RGB24}, img::GrayArray{F}) = ClampMinMax(RGB24, ze
 mapinfo{F<:Fractional}(::Type{ARGB32}, img::AbstractArray{F}) = ClampMinMax(ARGB32, zero(F), one(F))
 
 # Color->Color methods
-mapinfo(::Type{RGB{Ufixed8}}, img) = MapNone{RGB{Ufixed8}}()
-mapinfo(::Type{RGBA{Ufixed8}}, img) = MapNone{RGBA{Ufixed8}}()
+mapinfo(::Type{RGB{UFixed8}}, img) = MapNone{RGB{UFixed8}}()
+mapinfo(::Type{RGBA{UFixed8}}, img) = MapNone{RGBA{UFixed8}}()
 for (T,n) in bitshiftto8
-    @eval mapinfo(::Type{RGB{Ufixed8}}, img::AbstractArray{RGB{$T}}) = BitShift{RGB{Ufixed8},$n}()
-    @eval mapinfo(::Type{RGBA{Ufixed8}}, img::AbstractArray{RGBA{$T}}) = BitShift{RGBA{Ufixed8},$n}()
+    @eval mapinfo(::Type{RGB{UFixed8}}, img::AbstractArray{RGB{$T}}) = BitShift{RGB{UFixed8},$n}()
+    @eval mapinfo(::Type{RGBA{UFixed8}}, img::AbstractArray{RGBA{$T}}) = BitShift{RGBA{UFixed8},$n}()
 end
-mapinfo{F<:Fractional}(::Type{RGB{Ufixed8}}, img::AbstractArray{RGB{F}}) = Clamp(RGB{Ufixed8})
-mapinfo{F<:Fractional}(::Type{RGBA{Ufixed8}}, img::AbstractArray{RGBA{F}}) = Clamp(RGBA{Ufixed8})
+mapinfo{F<:Fractional}(::Type{RGB{UFixed8}}, img::AbstractArray{RGB{F}}) = Clamp(RGB{UFixed8})
+mapinfo{F<:Fractional}(::Type{RGBA{UFixed8}}, img::AbstractArray{RGBA{F}}) = Clamp(RGBA{UFixed8})
 
 
 
@@ -445,8 +445,8 @@ mapinfo(::Type{RGB24}, img::AbstractArray{RGB24}) = MapNone{RGB24}()
 mapinfo(::Type{ARGB32}, img::AbstractArray{ARGB32}) = MapNone{ARGB32}()
 for C in tuple(subtypes(AbstractRGB)..., Gray)
     C == RGB24 && continue
-    @eval mapinfo(::Type{RGB24}, img::AbstractArray{$C{Ufixed8}}) = MapNone{RGB24}()
-    @eval mapinfo(::Type{ARGB32}, img::AbstractArray{$C{Ufixed8}}) = MapNone{ARGB32}()
+    @eval mapinfo(::Type{RGB24}, img::AbstractArray{$C{UFixed8}}) = MapNone{RGB24}()
+    @eval mapinfo(::Type{ARGB32}, img::AbstractArray{$C{UFixed8}}) = MapNone{ARGB32}()
     for (T, n) in bitshiftto8
         @eval mapinfo(::Type{RGB24}, img::AbstractArray{$C{$T}}) = BitShift{RGB24, $n}()
         @eval mapinfo(::Type{ARGB32}, img::AbstractArray{$C{$T}}) = BitShift{ARGB32, $n}()
@@ -455,8 +455,8 @@ for C in tuple(subtypes(AbstractRGB)..., Gray)
     @eval mapinfo{F<:AbstractFloat}(::Type{ARGB32}, img::AbstractArray{$C{F}}) = ClampMinMax(ARGB32, zero(F), one(F))
     for AC in subtypes(TransparentColor)
         length(AC.parameters) == 2 || continue
-        @eval mapinfo(::Type{ARGB32}, img::AbstractArray{$AC{$C{Ufixed8},Ufixed8}}) = MapNone{ARGB32}()
-        @eval mapinfo(::Type{RGB24}, img::AbstractArray{$AC{$C{Ufixed8},Ufixed8}}) = MapNone{RGB24}()
+        @eval mapinfo(::Type{ARGB32}, img::AbstractArray{$AC{$C{UFixed8},UFixed8}}) = MapNone{ARGB32}()
+        @eval mapinfo(::Type{RGB24}, img::AbstractArray{$AC{$C{UFixed8},UFixed8}}) = MapNone{RGB24}()
         for (T, n) in bitshiftto8
             @eval mapinfo(::Type{ARGB32}, img::AbstractArray{$AC{$C{$T},$T}}) = BitShift{ARGB32, $n}()
             @eval mapinfo(::Type{RGB24}, img::AbstractArray{$AC{$C{$T},$T}}) = BitShift{RGB24, $n}()
@@ -478,29 +478,29 @@ mapinfo{CV<:TransparentColor}(::Type{UInt32}, img::AbstractArray{CV}) = mapinfo(
 mapinfo(::Type{UInt32}, img::AbstractArray{UInt32}) = MapNone{UInt32}()
 
 
-# Clamping mapinfo client. Converts to RGB and uses Ufixed, clamping
+# Clamping mapinfo client. Converts to RGB and uses UFixed, clamping
 # floating-point values to [0,1].
-mapinfo{T<:Ufixed}(::Type{Clamp}, img::AbstractArray{T}) = MapNone{T}()
-mapinfo{T<:AbstractFloat}(::Type{Clamp}, img::AbstractArray{T}) = ClampMinMax(Ufixed8, zero(T), one(T))
+mapinfo{T<:UFixed}(::Type{Clamp}, img::AbstractArray{T}) = MapNone{T}()
+mapinfo{T<:AbstractFloat}(::Type{Clamp}, img::AbstractArray{T}) = ClampMinMax(UFixed8, zero(T), one(T))
 for ACV in (Color, AbstractRGB)
     for CV in subtypes(ACV)
         (length(CV.parameters) == 1 && !(CV.abstract)) || continue
         CVnew = CV<:AbstractGray ? Gray : RGB
-        @eval mapinfo{T<:Ufixed}(::Type{Clamp}, img::AbstractArray{$CV{T}}) = MapNone{$CVnew{T}}()
-        @eval mapinfo{CV<:$CV}(::Type{Clamp}, img::AbstractArray{CV}) = Clamp{$CVnew{Ufixed8}}()
+        @eval mapinfo{T<:UFixed}(::Type{Clamp}, img::AbstractArray{$CV{T}}) = MapNone{$CVnew{T}}()
+        @eval mapinfo{CV<:$CV}(::Type{Clamp}, img::AbstractArray{CV}) = Clamp{$CVnew{UFixed8}}()
         CVnew = CV<:AbstractGray ? Gray : BGR
         AC, CA       = alphacolor(CV), coloralpha(CV)
         ACnew, CAnew = alphacolor(CVnew), coloralpha(CVnew)
         @eval begin
-            mapinfo{T<:Ufixed}(::Type{Clamp}, img::AbstractArray{$AC{T}}) = MapNone{$ACnew{T}}()
-            mapinfo{P<:$AC}(::Type{Clamp}, img::AbstractArray{P}) = Clamp{$ACnew{Ufixed8}}()
-            mapinfo{T<:Ufixed}(::Type{Clamp}, img::AbstractArray{$CA{T}}) = MapNone{$CAnew{T}}()
-            mapinfo{P<:$CA}(::Type{Clamp}, img::AbstractArray{P}) = Clamp{$CAnew{Ufixed8}}()
+            mapinfo{T<:UFixed}(::Type{Clamp}, img::AbstractArray{$AC{T}}) = MapNone{$ACnew{T}}()
+            mapinfo{P<:$AC}(::Type{Clamp}, img::AbstractArray{P}) = Clamp{$ACnew{UFixed8}}()
+            mapinfo{T<:UFixed}(::Type{Clamp}, img::AbstractArray{$CA{T}}) = MapNone{$CAnew{T}}()
+            mapinfo{P<:$CA}(::Type{Clamp}, img::AbstractArray{P}) = Clamp{$CAnew{UFixed8}}()
         end
     end
 end
-mapinfo(::Type{Clamp}, img::AbstractArray{RGB24}) = MapNone{RGB{Ufixed8}}()
-mapinfo(::Type{Clamp}, img::AbstractArray{ARGB32}) = MapNone{BGRA{Ufixed8}}()
+mapinfo(::Type{Clamp}, img::AbstractArray{RGB24}) = MapNone{RGB{UFixed8}}()
+mapinfo(::Type{Clamp}, img::AbstractArray{ARGB32}) = MapNone{BGRA{UFixed8}}()
 
 
 # Backwards-compatibility
@@ -517,12 +517,12 @@ uint32color!{T,N,N1}(buf::Array{UInt32,N}, img::AbstractImageDirect{T,N1}, mi::M
     map!(mi, buf, img, TypeConst{colordim(img)})
 
 
-sc(img::AbstractArray) = map(ScaleMinMax(Ufixed8, img), img)
-sc(img::AbstractArray, mn::Real, mx::Real) = map(ScaleMinMax(Ufixed8, img, mn, mx), img)
+sc(img::AbstractArray) = map(ScaleMinMax(UFixed8, img), img)
+sc(img::AbstractArray, mn::Real, mx::Real) = map(ScaleMinMax(UFixed8, img, mn, mx), img)
 
-for (fn,T) in ((:float32, Float32), (:float64, Float64), (:ufixed8, Ufixed8),
-               (:ufixed10, Ufixed10), (:ufixed12, Ufixed12), (:ufixed14, Ufixed14),
-               (:ufixed16, Ufixed16))
+for (fn,T) in ((:float32, Float32), (:float64, Float64), (:ufixed8, UFixed8),
+               (:ufixed10, UFixed10), (:ufixed12, UFixed12), (:ufixed14, UFixed14),
+               (:ufixed16, UFixed16))
     @eval begin
         function $fn{C<:Colorant}(A::AbstractArray{C})
             newC = eval(C.name.name){$T}
@@ -533,5 +533,5 @@ for (fn,T) in ((:float32, Float32), (:float64, Float64), (:ufixed8, Ufixed8),
 end
 
 
-ufixedsc{T<:Ufixed}(::Type{T}, img::AbstractImageDirect) = map(mapinfo(T, img), img)
-ufixed8sc(img::AbstractImageDirect) = ufixedsc(Ufixed8, img)
+ufixedsc{T<:UFixed}(::Type{T}, img::AbstractImageDirect) = map(mapinfo(T, img), img)
+ufixed8sc(img::AbstractImageDirect) = ufixedsc(UFixed8, img)

--- a/src/writemime.jl
+++ b/src/writemime.jl
@@ -45,12 +45,12 @@ function mapinfo_writemime(img; maxpixels=10^6)
     mapinfo_writemime_restricted(img)
 end
 
-to_native_color{T<:Colorant}(::Type{T}) = base_color_type(T){Ufixed8}
-to_native_color{T<:Color}(::Type{T}) = RGB{Ufixed8}
-to_native_color{T<:TransparentColor}(::Type{T}) = RGBA{Ufixed8}
+to_native_color{T<:Colorant}(::Type{T}) = base_color_type(T){UFixed8}
+to_native_color{T<:Color}(::Type{T}) = RGB{UFixed8}
+to_native_color{T<:TransparentColor}(::Type{T}) = RGBA{UFixed8}
 
 mapinfo_writemime_{T <:Colorant}(img::AbstractImage{T}) = Images.mapinfo(to_native_color(T), img)
-mapinfo_writemime_(img::AbstractImage) = Images.mapinfo(Ufixed8,img)
+mapinfo_writemime_(img::AbstractImage) = Images.mapinfo(UFixed8,img)
 
 mapinfo_writemime_restricted{T<:Colorant}(img::AbstractImage{T}) = ClampMinMax(to_native_color(T), 0.0, 1.0)
-mapinfo_writemime_restricted(img::AbstractImage) = Images.mapinfo(Ufixed8, img)
+mapinfo_writemime_restricted(img::AbstractImage) = Images.mapinfo(UFixed8, img)

--- a/test/algorithms.jl
+++ b/test/algorithms.jl
@@ -33,7 +33,7 @@ facts("Algorithms") do
         @fact all(A.*img2 .== fill(RGB{Float32}(1,1,1), 4, 5)) --> true
         img2 = img2 .- RGB{Float32}(1,1,1)/2
         A = rand(UInt8,3,4)
-        img = reinterpret(Images.Gray{Ufixed8}, Images.grayim(A))
+        img = reinterpret(Images.Gray{UFixed8}, Images.grayim(A))
         imgm = mean(img)
         imgn = img/imgm
         @fact reinterpret(Float32, Images.data(imgn)) --> roughly(convert(Array{Float32}, A/mean(A)))
@@ -59,7 +59,7 @@ facts("Algorithms") do
         A = rand(10:20, 5, 5)
         @fact minfinite(A) --> minimum(A)
         @fact maxfinite(A) --> maximum(A)
-        A = reinterpret(Ufixed8, rand(0x00:0xff, 5, 5))
+        A = reinterpret(UFixed8, rand(0x00:0xff, 5, 5))
         @fact minfinite(A) --> minimum(A)
         @fact maxfinite(A) --> maximum(A)
         A = rand(Float32,3,5,5)
@@ -75,16 +75,16 @@ facts("Algorithms") do
         b = convert(Array{UInt8}, [134, 252, 4])
         @fact Images.sad(a, b) --> 387
         @fact Images.ssd(a, b) --> 80699
-        af = reinterpret(Ufixed8, a)
-        bf = reinterpret(Ufixed8, b)
+        af = reinterpret(UFixed8, a)
+        bf = reinterpret(UFixed8, b)
         @fact Images.sad(af, bf) --> roughly(387f0/255)
         @fact Images.ssd(af, bf) --> roughly(80699f0/255^2)
-        ac = reinterpret(RGB{Ufixed8}, a)
-        bc = reinterpret(RGB{Ufixed8}, b)
+        ac = reinterpret(RGB{UFixed8}, a)
+        bc = reinterpret(RGB{UFixed8}, b)
         @fact Images.sad(ac, bc) --> roughly(387f0/255)
         @fact Images.ssd(ac, bc) --> roughly(80699f0/255^2)
-        ag = reinterpret(RGB{Ufixed8}, a)
-        bg = reinterpret(RGB{Ufixed8}, b)
+        ag = reinterpret(RGB{UFixed8}, a)
+        bg = reinterpret(RGB{UFixed8}, b)
         @fact Images.sad(ag, bg) --> roughly(387f0/255)
         @fact Images.ssd(ag, bg) --> roughly(80699f0/255^2)
 
@@ -145,7 +145,7 @@ facts("Algorithms") do
     context("Filtering") do
         EPS = 1e-14
         imgcol = Images.colorim(rand(3,5,6))
-        imgcolf = convert(Images.Image{RGB{Ufixed8}}, imgcol)
+        imgcolf = convert(Images.Image{RGB{UFixed8}}, imgcol)
         for T in (Float64, Int)
             A = zeros(T,3,3); A[2,2] = 1
             kern = rand(3,3)
@@ -251,13 +251,13 @@ facts("Algorithms") do
                        32.875    50.5   42.875;
                        16.90625  25.875 21.90625])
         @fact B --> roughly(Btarget)
-        Argb = reinterpret(RGB, reinterpret(Ufixed16, permutedims(A, (3,1,2))))
+        Argb = reinterpret(RGB, reinterpret(UFixed16, permutedims(A, (3,1,2))))
         B = Images.restrict(Argb)
         Bf = permutedims(reinterpret(Float64, B), (2,3,1))
-        @fact Bf --> roughly(Btarget/reinterpret(one(Ufixed16)), 1e-12)
-        Argba = reinterpret(RGBA{Ufixed16}, reinterpret(Ufixed16, A))
+        @fact Bf --> roughly(Btarget/reinterpret(one(UFixed16)), 1e-12)
+        Argba = reinterpret(RGBA{UFixed16}, reinterpret(UFixed16, A))
         B = Images.restrict(Argba)
-        @fact reinterpret(Float64, B) --> roughly(Images.restrict(A, (2,3))/reinterpret(one(Ufixed16)), 1e-12)
+        @fact reinterpret(Float64, B) --> roughly(Images.restrict(A, (2,3))/reinterpret(one(UFixed16)), 1e-12)
         A = reshape(1:60, 5, 4, 3)
         B = Images.restrict(A, (1,2,3))
         @fact cat(3, [ 2.6015625  8.71875 6.1171875;
@@ -366,7 +366,7 @@ facts("Algorithms") do
 
 context("Contrast") do
     # Issue #282
-    img = convert(Images.Image{Gray{Ufixed8}}, eye(2,2))
+    img = convert(Images.Image{Gray{UFixed8}}, eye(2,2))
     imgs = Images.imstretch(img, 0.3, 0.4)
     @fact data(imgs) --> roughly(1./(1 + (0.3./(eye(2,2) + eps())).^0.4))
 end

--- a/test/core.jl
+++ b/test/core.jl
@@ -8,12 +8,11 @@ end
 facts("Core") do
     a = rand(3,3)
     @inferred(Image(a))
-
-    # support integer-valued types, but these are NOT recommended (use Ufixed)
+    # support integer-valued types, but these are NOT recommended (use UFixed)
     B = rand(convert(UInt16, 1):convert(UInt16, 20), 3, 5)
     # img, imgd, and imgds will be used in many more tests
     # Thus, these must be defined as local if reassigned in any context() blocks
-    cmap = reinterpret(RGB, repmat(reinterpret(Ufixed8, round(UInt8, linspace(12, 255, 20)))', 3, 1))
+    cmap = reinterpret(RGB, repmat(reinterpret(UFixed8, round(UInt8, linspace(12, 255, 20)))', 3, 1))
     img = ImageCmap(copy(B), cmap, Dict{ASCIIString, Any}([("pixelspacing", [2.0, 3.0]), ("spatialorder", Images.yx)]))
     imgd = convert(Image, img)
     if testing_units
@@ -31,43 +30,43 @@ facts("Core") do
         @fact colorspace(img) --> "Gray"
         @fact colordim(B) --> 0
         @fact grayim(img) --> img
-        # this is recommended for "integer-valued" images (or even better, directly as a Ufixed type)
+        # this is recommended for "integer-valued" images (or even better, directly as a UFixed type)
         Bf = grayim(round(UInt8, B))
-        @fact eltype(Bf) --> Ufixed8
+        @fact eltype(Bf) --> UFixed8
         @fact colorspace(Bf) --> "Gray"
         @fact colordim(Bf) --> 0
         Bf = grayim(B)
-        @fact eltype(Bf) --> Ufixed16
+        @fact eltype(Bf) --> UFixed16
         # colorspace encoded as a Color (enables multiple dispatch)
-        BfCV = reinterpret(Gray{Ufixed8}, round(UInt8, B))
+        BfCV = reinterpret(Gray{UFixed8}, round(UInt8, B))
         @fact colorspace(BfCV) --> "Gray"
         @fact colordim(BfCV) --> 0
         Bf3 = grayim(reshape(convert(UInt8,1):convert(UInt8,36), 3,4,3))
-        @fact eltype(Bf3) --> Ufixed8
+        @fact eltype(Bf3) --> UFixed8
         Bf3 = grayim(reshape(convert(UInt16,1):convert(UInt16,36), 3,4,3))
-        @fact eltype(Bf3) --> Ufixed16
+        @fact eltype(Bf3) --> UFixed16
         Bf3 = grayim(reshape(1.0f0:36.0f0, 3,4,3))
         @fact eltype(Bf3) --> Float32
     end
 
     context("Colorim") do
         C = colorim(rand(UInt8, 3, 5, 5))
-        @fact eltype(C) --> RGB{Ufixed8}
+        @fact eltype(C) --> RGB{UFixed8}
         @fact colordim(C) --> 0
         @fact colorim(C) --> C
         C = colorim(rand(UInt16, 4, 5, 5), "ARGB")
-        @fact eltype(C) --> ARGB{Ufixed16}
+        @fact eltype(C) --> ARGB{UFixed16}
         C = colorim(rand(1:20, 3, 5, 5))
         @fact eltype(C) --> Int
         @fact colordim(C) --> 1
         @fact colorspace(C) --> "RGB"
-        @fact eltype(colorim(rand(UInt16, 3, 5, 5))) --> RGB{Ufixed16}
+        @fact eltype(colorim(rand(UInt16, 3, 5, 5))) --> RGB{UFixed16}
         @fact eltype(colorim(rand(3, 5, 5))) --> RGB{Float64}
         @fact colordim(colorim(rand(UInt8, 5, 5, 3))) --> 3
         @fact spatialorder(colorim(rand(UInt8, 3, 5, 5))) --> ["x", "y"]
         @fact spatialorder(colorim(rand(UInt8, 5, 5, 3))) --> ["y", "x"]
-        @fact eltype(colorim(rand(UInt8, 4, 5, 5), "RGBA")) --> RGBA{Ufixed8}
-        @fact eltype(colorim(rand(UInt8, 4, 5, 5), "ARGB")) --> ARGB{Ufixed8}
+        @fact eltype(colorim(rand(UInt8, 4, 5, 5), "RGBA")) --> RGBA{UFixed8}
+        @fact eltype(colorim(rand(UInt8, 4, 5, 5), "ARGB")) --> ARGB{UFixed8}
         @fact colordim(colorim(rand(UInt8, 5, 5, 4), "RGBA")) --> 3
         @fact colordim(colorim(rand(UInt8, 5, 5, 4), "ARGB")) --> 3
         @fact spatialorder(colorim(rand(UInt8, 4, 5, 5), "ARGB")) --> ["x", "y"]
@@ -88,8 +87,8 @@ facts("Core") do
         @fact colorspace(img_) --> "RGB"
         # Note: img from opening of facts() block
         # TODO: refactor whole block
-        @fact eltype(img) --> RGB{Ufixed8}
-        @fact eltype(imgd) --> RGB{Ufixed8}
+        @fact eltype(img) --> RGB{UFixed8}
+        @fact eltype(imgd) --> RGB{UFixed8}
     end
 
 
@@ -375,46 +374,46 @@ facts("Core") do
         @fact anew --> a
         @fact_throws ErrorException reinterpret(RGB{Float32}, af)
         Au8 = rand(0x00:0xff, 3, 5, 4)
-        A8 = reinterpret(Ufixed8, Au8)
+        A8 = reinterpret(UFixed8, Au8)
         rawrgb8 = reinterpret(RGB, A8)
-        @fact eltype(rawrgb8) --> RGB{Ufixed8}
-        @fact reinterpret(Ufixed8, rawrgb8) --> A8
+        @fact eltype(rawrgb8) --> RGB{UFixed8}
+        @fact reinterpret(UFixed8, rawrgb8) --> A8
         @fact reinterpret(UInt8, rawrgb8) --> Au8
         rawrgb32 = convert(Array{RGB{Float32}}, rawrgb8)
         @fact eltype(rawrgb32) --> RGB{Float32}
         @fact ufixed8(rawrgb32) --> rawrgb8
-        @fact reinterpret(Ufixed8, rawrgb8) --> A8
+        @fact reinterpret(UFixed8, rawrgb8) --> A8
         imrgb8 = convert(Image, rawrgb8)
         @fact spatialorder(imrgb8) --> Images.yx
         @fact convert(Image, imrgb8) --> exactly(imrgb8)
-        @fact convert(Image{RGB{Ufixed8}}, imrgb8) --> exactly(imrgb8)
-        im8 = reinterpret(Ufixed8, imrgb8)
+        @fact convert(Image{RGB{UFixed8}}, imrgb8) --> exactly(imrgb8)
+        im8 = reinterpret(UFixed8, imrgb8)
         @fact data(im8) --> A8
-        @fact permutedims(reinterpret(Ufixed8, separate(imrgb8)), (3, 1, 2)) --> im8
+        @fact permutedims(reinterpret(UFixed8, separate(imrgb8)), (3, 1, 2)) --> im8
         @fact reinterpret(UInt8, imrgb8) --> Au8
         @fact reinterpret(RGB, im8) --> imrgb8
         ims8 = separate(imrgb8)
         @fact colordim(ims8) --> 3
         @fact colorspace(ims8) --> "RGB"
         @fact convert(Image, ims8) --> exactly(ims8)
-        @fact convert(Image{Ufixed8}, ims8) --> exactly(ims8)
+        @fact convert(Image{UFixed8}, ims8) --> exactly(ims8)
         @fact separate(ims8) --> exactly(ims8)
         imrgb8_2 = convert(Image{RGB}, ims8)
-        @fact isa(imrgb8_2, Image{RGB{Ufixed8}}) --> true
+        @fact isa(imrgb8_2, Image{RGB{UFixed8}}) --> true
         @fact imrgb8_2 --> imrgb8
-        A = reinterpret(Ufixed8, UInt8[1 2; 3 4])
-        imgray = convert(Image{Gray{Ufixed8}}, A)
+        A = reinterpret(UFixed8, UInt8[1 2; 3 4])
+        imgray = convert(Image{Gray{UFixed8}}, A)
         @fact spatialorder(imgray) --> Images.yx
-        @fact data(imgray) --> reinterpret(Gray{Ufixed8}, [0x01 0x02; 0x03 0x04])
+        @fact data(imgray) --> reinterpret(Gray{UFixed8}, [0x01 0x02; 0x03 0x04])
         @fact eltype(convert(Image{HSV{Float32}}, imrgb8)) --> HSV{Float32}
         @fact eltype(convert(Image{HSV}, float32(imrgb8))) --> HSV{Float32}
         # Issue 232
-        local img = Image(reinterpret(Gray{Ufixed16}, rand(UInt16, 5, 5)))
+        local img = Image(reinterpret(Gray{UFixed16}, rand(UInt16, 5, 5)))
         imgs = subim(img, :, :)
-        @fact isa(minfinite(imgs), Ufixed16) --> true
+        @fact isa(minfinite(imgs), UFixed16) --> true
         # Raw
         imgdata = rand(UInt16, 5, 5)
-        img = Image(reinterpret(Gray{Ufixed16}, imgdata))
+        img = Image(reinterpret(Gray{UFixed16}, imgdata))
         @fact all(raw(img) .== imgdata) --> true
         @fact typeof(raw(img)) --> Array{UInt16,2}
         @fact typeof(raw(Image(rawrgb8))) --> Array{UInt8,3}  # check color images

--- a/test/map.jl
+++ b/test/map.jl
@@ -17,7 +17,7 @@ facts("Map") do
         @chk map(mapi, [0x07]) a7
         @fact map(mapi, a7) --> exactly(a7)
         mapi = MapNone{RGB24}()
-        g = Ufixed8(0.1)
+        g = UFixed8(0.1)
         @chk Images.map1(mapi, 0.1) g
         @chk map(mapi, 0.1) RGB24(g,g,g)
         @chk map(mapi, Gray(0.1)) RGB24(g,g,g)
@@ -34,9 +34,9 @@ facts("Map") do
         @chk map(mapi, c) convert(HSV, c)
 
         # issue #200
-        c = RGBA{Ufixed8}(1,0.5,0.25,0.8)
-        mapi = MapNone{Images.ColorTypes.BGRA{Ufixed8}}()
-        @chk map(mapi, c) convert(Images.ColorTypes.BGRA{Ufixed8}, c)
+        c = RGBA{UFixed8}(1,0.5,0.25,0.8)
+        mapi = MapNone{Images.ColorTypes.BGRA{UFixed8}}()
+        @chk map(mapi, c) convert(Images.ColorTypes.BGRA{UFixed8}, c)
     end
 
     context("BitShift") do
@@ -44,7 +44,7 @@ facts("Map") do
         @chk map(mapi, 0xff) 0x01
         @chk map(mapi, 0xf0ff) 0xff
         @chk map(mapi, [0xff]) UInt8[0x01]
-        mapi = BitShift{Ufixed8,7}()
+        mapi = BitShift{UFixed8,7}()
         @chk map(mapi, 0xffuf8) 0x01uf8
         @chk map(mapi, 0xf0ffuf16) 0xffuf8
         mapi = BitShift{ARGB32,4}()
@@ -53,23 +53,23 @@ facts("Map") do
         @chk map(mapi, Gray(0xffuf8)) RGB24(0x003f3f3f)
         mapi = BitShift{ARGB32,2}()
         @chk map(mapi, Gray(0xffuf8)) ARGB32(0xff3f3f3f)
-        @chk map(mapi, GrayA{Ufixed8}(Gray(0xffuf8),0x3fuf8)) ARGB32(0x0f3f3f3f)
-        mapi = BitShift{RGB{Ufixed8},2}()
+        @chk map(mapi, GrayA{UFixed8}(Gray(0xffuf8),0x3fuf8)) ARGB32(0x0f3f3f3f)
+        mapi = BitShift{RGB{UFixed8},2}()
         @chk map(mapi, Gray(0xffuf8)) RGB(0x3fuf8, 0x3fuf8, 0x3fuf8)
-        mapi = BitShift{ARGB{Ufixed8},2}()
-        @chk map(mapi, Gray(0xffuf8)) ARGB{Ufixed8}(0x3fuf8, 0x3fuf8, 0x3fuf8, 0xffuf8)
-        @chk map(mapi, GrayA{Ufixed8}(Gray(0xffuf8),0x3fuf8)) ARGB{Ufixed8}(0x3fuf8, 0x3fuf8, 0x3fuf8, 0x0fuf8)
-        mapi = BitShift{RGBA{Ufixed8},2}()
-        @chk map(mapi, Gray(0xffuf8)) RGBA{Ufixed8}(0x3fuf8, 0x3fuf8, 0x3fuf8, 0xffuf8)
-        @chk map(mapi, GrayA{Ufixed8}(Gray(0xffuf8),0x3fuf8)) RGBA{Ufixed8}(0x3fuf8, 0x3fuf8, 0x3fuf8, 0x0fuf8)
-        mapi = BitShift(ARGB{Ufixed8}, 8)
-        @chk map(mapi, RGB{Ufixed16}(1.0,0.8,0.6)) ARGB{Ufixed8}(1.0,0.8,0.6,1.0)
-        mapi = BitShift(RGBA{Ufixed8}, 8)
-        @chk map(mapi, RGB{Ufixed16}(1.0,0.8,0.6)) RGBA{Ufixed8}(1.0,0.8,0.6,1.0)
+        mapi = BitShift{ARGB{UFixed8},2}()
+        @chk map(mapi, Gray(0xffuf8)) ARGB{UFixed8}(0x3fuf8, 0x3fuf8, 0x3fuf8, 0xffuf8)
+        @chk map(mapi, GrayA{UFixed8}(Gray(0xffuf8),0x3fuf8)) ARGB{UFixed8}(0x3fuf8, 0x3fuf8, 0x3fuf8, 0x0fuf8)
+        mapi = BitShift{RGBA{UFixed8},2}()
+        @chk map(mapi, Gray(0xffuf8)) RGBA{UFixed8}(0x3fuf8, 0x3fuf8, 0x3fuf8, 0xffuf8)
+        @chk map(mapi, GrayA{UFixed8}(Gray(0xffuf8),0x3fuf8)) RGBA{UFixed8}(0x3fuf8, 0x3fuf8, 0x3fuf8, 0x0fuf8)
+        mapi = BitShift(ARGB{UFixed8}, 8)
+        @chk map(mapi, RGB{UFixed16}(1.0,0.8,0.6)) ARGB{UFixed8}(1.0,0.8,0.6,1.0)
+        mapi = BitShift(RGBA{UFixed8}, 8)
+        @chk map(mapi, RGB{UFixed16}(1.0,0.8,0.6)) RGBA{UFixed8}(1.0,0.8,0.6,1.0)
         # Issue, #269, IJulia issue #294
-        bs = BitShift(Gray{Ufixed8}, 8)
+        bs = BitShift(Gray{UFixed8}, 8)
         v = Gray(ufixed16(0.8))
-        @chk map(bs, v) Gray{Ufixed8}(0.8)
+        @chk map(bs, v) Gray{UFixed8}(0.8)
     end
 
     context("Clamp") do
@@ -92,35 +92,35 @@ facts("Map") do
         mapi = Clamp(Float32)
         @chk map(mapi,  1.2) 1.0f0
         @chk map(mapi, -1.2) 0.0f0
-        mapi = Clamp(Ufixed12)
-        @chk map(mapi, Ufixed12(1.2)) one(Ufixed12)
-        mapi = Clamp(Gray{Ufixed12})
-        @chk map(mapi, Gray(Ufixed12(1.2))) Gray(one(Ufixed12))
+        mapi = Clamp(UFixed12)
+        @chk map(mapi, UFixed12(1.2)) one(UFixed12)
+        mapi = Clamp(Gray{UFixed12})
+        @chk map(mapi, Gray(UFixed12(1.2))) Gray(one(UFixed12))
         mapi = ClampMinMax(RGB24, 0.0, 1.0)
         @chk map(mapi, 1.2) RGB24(0x00ffffff)
         @chk map(mapi, 0.5) RGB24(0x00808080)
         @chk map(mapi, -.3) RGB24(0x00000000)
-        mapi = ClampMinMax(RGB{Ufixed8}, 0.0, 1.0)
-        @chk map(mapi, 1.2) RGB{Ufixed8}(1,1,1)
-        @chk map(mapi, 0.5) RGB{Ufixed8}(0.5,0.5,0.5)
-        @chk map(mapi, -.3) RGB{Ufixed8}(0,0,0)
-        mapi = Clamp(RGB{Ufixed8})
-        @chk map(mapi, RGB(1.2,0.5,-.3)) RGB{Ufixed8}(1,0.5,0)
-        mapi = Clamp(ARGB{Ufixed8})
-        @chk map(mapi, ARGB{Float64}(1.2,0.5,-.3,0.2)) ARGB{Ufixed8}(1.0,0.5,0.0,0.2)
-        @chk map(mapi, RGBA{Float64}(1.2,0.5,-.3,0.2)) ARGB{Ufixed8}(1.0,0.5,0.0,0.2)
-        @chk map(mapi, 0.2) ARGB{Ufixed8}(0.2,0.2,0.2,1.0)
-        @chk map(mapi, GrayA{Float32}(Gray(0.2),1.2)) ARGB{Ufixed8}(0.2,0.2,0.2,1.0)
-        @chk map(mapi, GrayA{Float32}(Gray(-.4),0.8)) ARGB{Ufixed8}(0.0,0.0,0.0,0.8)
-        mapi = Clamp(RGBA{Ufixed8})
-        @chk map(mapi, ARGB{Float64}(1.2,0.5,-.3,0.2)) RGBA{Ufixed8}(1.0,0.5,0.0,0.2)
-        @chk map(mapi, RGBA{Float64}(1.2,0.5,-.3,0.2)) RGBA{Ufixed8}(1.0,0.5,0.0,0.2)
-        @chk map(mapi, 0.2) RGBA{Ufixed8}(0.2,0.2,0.2,1.0)
-        @chk map(mapi, GrayA{Float32}(Gray(0.2),1.2)) RGBA{Ufixed8}(0.2,0.2,0.2,1.0)
-        @chk map(mapi, GrayA{Float32}(Gray(-.4),0.8)) RGBA{Ufixed8}(0.0,0.0,0.0,0.8)
+        mapi = ClampMinMax(RGB{UFixed8}, 0.0, 1.0)
+        @chk map(mapi, 1.2) RGB{UFixed8}(1,1,1)
+        @chk map(mapi, 0.5) RGB{UFixed8}(0.5,0.5,0.5)
+        @chk map(mapi, -.3) RGB{UFixed8}(0,0,0)
+        mapi = Clamp(RGB{UFixed8})
+        @chk map(mapi, RGB(1.2,0.5,-.3)) RGB{UFixed8}(1,0.5,0)
+        mapi = Clamp(ARGB{UFixed8})
+        @chk map(mapi, ARGB{Float64}(1.2,0.5,-.3,0.2)) ARGB{UFixed8}(1.0,0.5,0.0,0.2)
+        @chk map(mapi, RGBA{Float64}(1.2,0.5,-.3,0.2)) ARGB{UFixed8}(1.0,0.5,0.0,0.2)
+        @chk map(mapi, 0.2) ARGB{UFixed8}(0.2,0.2,0.2,1.0)
+        @chk map(mapi, GrayA{Float32}(Gray(0.2),1.2)) ARGB{UFixed8}(0.2,0.2,0.2,1.0)
+        @chk map(mapi, GrayA{Float32}(Gray(-.4),0.8)) ARGB{UFixed8}(0.0,0.0,0.0,0.8)
+        mapi = Clamp(RGBA{UFixed8})
+        @chk map(mapi, ARGB{Float64}(1.2,0.5,-.3,0.2)) RGBA{UFixed8}(1.0,0.5,0.0,0.2)
+        @chk map(mapi, RGBA{Float64}(1.2,0.5,-.3,0.2)) RGBA{UFixed8}(1.0,0.5,0.0,0.2)
+        @chk map(mapi, 0.2) RGBA{UFixed8}(0.2,0.2,0.2,1.0)
+        @chk map(mapi, GrayA{Float32}(Gray(0.2),1.2)) RGBA{UFixed8}(0.2,0.2,0.2,1.0)
+        @chk map(mapi, GrayA{Float32}(Gray(-.4),0.8)) RGBA{UFixed8}(0.0,0.0,0.0,0.8)
         # Issue #253
-        mapi = Clamp(BGRA{Ufixed8})
-        @chk map(mapi, RGBA{Float32}(1.2,0.5,-.3,0.2)) BGRA{Ufixed8}(1.0,0.5,0.0,0.2)
+        mapi = Clamp(BGRA{UFixed8})
+        @chk map(mapi, RGBA{Float32}(1.2,0.5,-.3,0.2)) BGRA{UFixed8}(1.0,0.5,0.0,0.2)
 
         @chk clamp(RGB{Float32}(-0.2,0.5,1.8)) RGB{Float32}(0.0,0.5,1.0)
         @chk clamp(ARGB{Float64}(1.2,0.5,-.3,0.2)) ARGB{Float64}(1.0,0.5,0.0,0.2)
@@ -130,20 +130,20 @@ facts("Map") do
     context("Issue #285") do
         a = [Gray(0xd0uf8)]
         a1 = 10*a
-        mapi = mapinfo(Gray{Ufixed8}, a1)
+        mapi = mapinfo(Gray{UFixed8}, a1)
         @chk map(mapi, a1[1]) Gray(0xffuf8)
     end
 
     context("ScaleMinMax") do
-        mapi = ScaleMinMax(Ufixed8, 100, 1000)
-        @chk map(mapi, 100) Ufixed8(0.0)
-        @chk map(mapi, 1000) Ufixed8(1.0)
-        @chk map(mapi, 10) Ufixed8(0.0)
-        @chk map(mapi, 2000) Ufixed8(1.0)
-        @chk map(mapi, 550) Ufixed8(0.5)
-        mapinew = ScaleMinMax(Ufixed8, [100,500,1000])
+        mapi = ScaleMinMax(UFixed8, 100, 1000)
+        @chk map(mapi, 100) UFixed8(0.0)
+        @chk map(mapi, 1000) UFixed8(1.0)
+        @chk map(mapi, 10) UFixed8(0.0)
+        @chk map(mapi, 2000) UFixed8(1.0)
+        @chk map(mapi, 550) UFixed8(0.5)
+        mapinew = ScaleMinMax(UFixed8, [100,500,1000])
         @fact mapinew --> mapi
-        mapinew = ScaleMinMax(Ufixed8, [0,500,2000], convert(UInt16, 100), convert(UInt16, 1000))
+        mapinew = ScaleMinMax(UFixed8, [0,500,2000], convert(UInt16, 100), convert(UInt16, 1000))
         @fact mapinew --> mapi
         mapi = ScaleMinMax(ARGB32, 100, 1000)
         @chk map(mapi, 100) ARGB32(0,0,0,1)
@@ -153,16 +153,16 @@ facts("Map") do
         @chk map(mapi,  50) RGB(0.0f0, 0.0f0, 0.0f0)
         @chk map(mapi, 550) RGB{Float32}(0.5, 0.5, 0.5)
         @chk map(mapi,2000) RGB(1.0f0, 1.0f0, 1.0f0)
-        A = Gray{Ufixed8}[Ufixed8(0.1), Ufixed8(0.9)]
+        A = Gray{UFixed8}[UFixed8(0.1), UFixed8(0.9)]
         @fact mapinfo(RGB24, A) --> MapNone{RGB24}()
-        mapi = ScaleMinMax(RGB24, A, zero(Gray{Ufixed8}), one(Gray{Ufixed8}))
+        mapi = ScaleMinMax(RGB24, A, zero(Gray{UFixed8}), one(Gray{UFixed8}))
         @fact map(mapi, A) --> map(mapinfo(RGB24, A), A)
-        mapi = ScaleMinMax(Float32, [Gray(one(Ufixed8))], 0, 1) # issue #180
-        @chk map(mapi, Gray(Ufixed8(0.6))) 0.6f0
+        mapi = ScaleMinMax(Float32, [Gray(one(UFixed8))], 0, 1) # issue #180
+        @chk map(mapi, Gray(UFixed8(0.6))) 0.6f0
         @fact_throws ErrorException ScaleMinMax(Float32, 0, 0, 1.0) # issue #245
         A = [Gray{Float64}(0.2)]
-        mapi = ScaleMinMax(RGB{Ufixed8}, A, 0.0, 0.2)
-        @fact map(mapi, A) --> [RGB{Ufixed8}(1,1,1)]
+        mapi = ScaleMinMax(RGB{UFixed8}, A, 0.0, 0.2)
+        @fact map(mapi, A) --> [RGB{UFixed8}(1,1,1)]
         mapi = ScaleMinMax(Gray{U8}, Gray{U8}(0.2), Gray{U8}(0.4))
         @chk_approx map(mapi, Gray{U8}(0.3)) Gray{U8}(0.5)
         @chk_approx map(mapi, 0.3) Gray{U8}(0.5)
@@ -194,9 +194,9 @@ facts("Map") do
         # Issue #304
         A = rand(UInt16, 3, 2, 2)
         imgr = colorim(A)
-        mi1 = ScaleAutoMinMax(RGB{Ufixed16})
+        mi1 = ScaleAutoMinMax(RGB{UFixed16})
         res1 = raw(map(mi1, imgr))
-        mi2 = ScaleAutoMinMax(Ufixed16)
+        mi2 = ScaleAutoMinMax(UFixed16)
         res2 = raw(map(mi2, raw(imgr)))
         if res1 != res2
             @show A
@@ -206,9 +206,9 @@ facts("Map") do
 
     context("Scaling and ssd") do
         img = Images.grayim(fill(typemax(UInt16), 3, 3))
-        mapi = Images.mapinfo(Ufixed8, img)
+        mapi = Images.mapinfo(UFixed8, img)
         img8 = map(mapi, img)
-        @fact all(img8 .== typemax(Ufixed8)) --> true
+        @fact all(img8 .== typemax(UFixed8)) --> true
         A = 0
         mnA, mxA = 1.0, -1.0
         while mnA > 0 || mxA < 0
@@ -217,11 +217,11 @@ facts("Map") do
         end
         offset = 30.0
         img = convert(Images.Image, A .+ offset)
-        mapi = Images.ScaleMinMax(Ufixed8, offset, offset+mxA, 1/mxA)
+        mapi = Images.ScaleMinMax(UFixed8, offset, offset+mxA, 1/mxA)
         imgs = map(mapi, img)
         @fact minimum(imgs) --> 0
         @fact maximum(imgs) --> 1
-        @fact eltype(imgs) --> Ufixed8
+        @fact eltype(imgs) --> UFixed8
         imgs = Images.imadjustintensity(img, [])
         @fact_throws ErrorException Images.imadjustintensity(img, [1])
         mnA = minimum(A)
@@ -232,8 +232,8 @@ facts("Map") do
         B = map(Images.ClampMax(UInt8, 7), A)
         @fact (eltype(B) == UInt8 && B == [1 4 7; 2 5 7; 3 6 7]) --> true
 
-        A = reinterpret(Ufixed8, [convert(UInt8,1):convert(UInt8,24);], (3, 2, 4))
-        img = reinterpret(RGB{Ufixed8}, A, (2,4))
+        A = reinterpret(UFixed8, [convert(UInt8,1):convert(UInt8,24);], (3, 2, 4))
+        img = reinterpret(RGB{UFixed8}, A, (2,4))
         @fact separate(img) --> permutedims(A, (2,3,1))
     end
 
@@ -274,10 +274,10 @@ facts("Map") do
     end
 
     context("Map and indexed images") do
-        img = Images.ImageCmap([1 2 3; 3 2 1], [RGB{Ufixed16}(1.0,0.6,0.4), RGB{Ufixed16}(0.2, 0.4, 0.6), RGB{Ufixed16}(0.5,0.5,0.5)])
-        mapi = MapNone(RGB{Ufixed8})
+        img = Images.ImageCmap([1 2 3; 3 2 1], [RGB{UFixed16}(1.0,0.6,0.4), RGB{UFixed16}(0.2, 0.4, 0.6), RGB{UFixed16}(0.5,0.5,0.5)])
+        mapi = MapNone(RGB{UFixed8})
         imgd = map(mapi, img)
-        cmap = [RGB{Ufixed8}(1.0,0.6,0.4), RGB{Ufixed8}(0.2, 0.4, 0.6), RGB{Ufixed8}(0.5,0.5,0.5)]
+        cmap = [RGB{UFixed8}(1.0,0.6,0.4), RGB{UFixed8}(0.2, 0.4, 0.6), RGB{UFixed8}(0.5,0.5,0.5)]
         @fact imgd --> reshape(cmap[[1,3,2,2,3,1]], (2,3))
     end
 end

--- a/test/overlays.jl
+++ b/test/overlays.jl
@@ -20,10 +20,10 @@ facts("Overlay") do
     end
 
     context("Two") do
-        local ovr = Images.Overlay((gray, 0*gray), (RGB{Ufixed8}(1, 0, 1), RGB{Ufixed8}(0, 1, 0)), ((0, 1), (0, 1)))
-        @fact eltype(ovr) --> RGB{Ufixed8}
+        local ovr = Images.Overlay((gray, 0*gray), (RGB{UFixed8}(1, 0, 1), RGB{UFixed8}(0, 1, 0)), ((0, 1), (0, 1)))
+        @fact eltype(ovr) --> RGB{UFixed8}
         s = similar(ovr)
-        @fact isa(s, Vector{RGB{Ufixed8}}) --> true
+        @fact isa(s, Vector{RGB{UFixed8}}) --> true
         @fact length(s) --> 5
         s = similar(ovr, RGB{Float32})
         @fact isa(s, Vector{RGB{Float32}}) --> true

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,7 +12,6 @@ if testing_units
     using SIUnits, SIUnits.ShortUnits
 end
 
-FactCheck.setstyle(:compact)
 
 include("core.jl")
 include("map.jl")

--- a/test/writemime.jl
+++ b/test/writemime.jl
@@ -13,7 +13,7 @@ facts("Writemime") do
         b = open(fn, "r") do io 
         	deserialize(io)
         end
-        abigui = convert(Array{Ufixed8,2}, data(restrict(abig, (1,2))))
-        @fact data(b) --> convert(Array{Ufixed8,2}, data(restrict(abig, (1,2))))
+        abigui = convert(Array{UFixed8,2}, data(restrict(abig, (1,2))))
+        @fact data(b) --> convert(Array{UFixed8,2}, data(restrict(abig, (1,2))))
     end
 end


### PR DESCRIPTION
```Julia
mapi = ScaleMinMax(Gray{U8}, Gray{U8}(0.2), Gray{U8}(0.4))
@chk_approx map(mapi, Gray{U8}(0.3)) Gray{U8}(0.5)
@chk_approx map(mapi, 0.3) Gray{U8}(0.5)
mapi = ScaleMinMax(Gray{U8}, 0.2, 0.4)
@chk_approx map(mapi, Gray{U8}(0.3)) Gray{U8}(0.5)
@chk_approx map(mapi, 0.3) Gray{U8}(0.5)
```
(`Gray{U8}(0.49)` is the result)
and
```Julia
A = rand(UInt8,3,4)
img = reinterpret(Images.Gray{UFixed8}, Images.grayim(A))
imgm = mean(img)
imgn = img/imgm
@fact reinterpret(Float32, Images.data(imgn)) -->
roughly(convert(Array{Float32}, A/mean(A)))
```
Fail.
Other tests fail on Master + last tagged `FixedPointNumbers` version, so I guess this is due to a change in FixedPointNumbers?!