### PR TITLE
add exports for ufixedsc and ufixed8sc

### DIFF
--- a/src/Images.jl
+++ b/src/Images.jl
@@ -169,6 +169,8 @@ export # types
     uint8sc,
     uint16sc,
     uint32sc,
+    ufixed8sc,
+    ufixedsc,
 
     # algorithms
     ando3,


### PR DESCRIPTION
The deprecation warning of `uint8sc` points to `ufixed8sc`, but that is not exported yet.