### PR TITLE
Don't clone FileIO manually in CI scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ notifications:
     email: false
 script:
     - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-    - julia -e 'Pkg.clone("https://github.com/JuliaIO/FileIO.jl.git")'
     - julia -e 'Pkg.clone(pwd()); Pkg.build("Images")'
     - julia -e 'Pkg.test("Images", coverage=true)'
 after_success:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,8 +32,7 @@ install:
 build_script:
 # Need to convert from shallow to complete for Pkg.clone to work
   - IF EXIST .git\shallow (git fetch --unshallow)
-  - C:\projects\julia\bin\julia -F -e "versioninfo(); Pkg.clone(\"https://github.com/JuliaIO/FileIO.jl.git\", \"FileIO\")"
-  - C:\projects\julia\bin\julia -F -e "Pkg.clone(pwd(), \"Images\"); Pkg.build(\"Images\")"
+  - C:\projects\julia\bin\julia -e "versioninfo(); Pkg.clone(pwd(), \"Images\"); Pkg.build(\"Images\")"
 
 test_script:
   - C:\projects\julia\bin\julia --check-bounds=yes -e "Pkg.test(\"Images\")"


### PR DESCRIPTION
Now that FileIO is registered and tagged, we shouldn't need these anymore.