### PR TITLE
Improve type stability of Image constructor

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -12,6 +12,7 @@ type Image{T,N,A<:AbstractArray} <: AbstractImageDirect{T,N}
     properties::Dict{ASCIIString,Any}
 end
 Image(data::AbstractArray, props::Dict) = Image{eltype(data),ndims(data),typeof(data)}(data,props)
+Image{T,N}(data::AbstractArray{T,N}, props::Dict) = Image{T,N,typeof(data)}(data,props)
 Image(data::AbstractArray; kwargs...) = Image(data, kwargs2dict(kwargs))
 
 # Indexed image (colormap)


### PR DESCRIPTION
Inference is run before the inlining pass, so when inference runs on constructors of the form `T{ndims(A)}(...)`, it does't see the inlined constant; it just sees an Int.  The fix is to just use the type parameters directly.  I've added this as an additional constructor to make sure it doesn't break any existing code with very poorly typed arrays.