### PR TITLE
Docstrings!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
     - osx
 julia:
     - 0.4
-    - nightly
+#    - nightly
 notifications:
     email: false
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,8 +2,8 @@ environment:
   matrix:
   - JULIAVERSION: "julialang/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
   - JULIAVERSION: "julialang/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
-  - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
-  - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
+#  - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
+#  - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
 
 branches:
   only:

--- a/doc/function_reference.md
+++ b/doc/function_reference.md
@@ -530,16 +530,15 @@ converted to a new type.
 
 Here is how to directly construct the major concrete `MapInfo` types:
 
-- `MapNone(T)`, indicating that the only form of scaling is conversion to type
-  T.  This is not very safe, as values "wrap around": for example, converting
-  `258` to a `Uint8` results in `0x02`, which would look dimmer than `255 =
-  0xff`.
+- `MapNone(T)`, indicating that the only form of scaling is conversion
+  to type T.  This can throw an error if a value `x` cannot be
+  represented as an object of type `T`, e.g., `map(MapNone{U8}, 1.2)`.
 
-- `ClampMin(T, minvalue)`, `ClampMax(T, maxvalue)`, and `ClampMinMax(T,
-  minvalue, maxvalue)` create `MapInfo` objects that clamp pixel values at the
-  specified min, max, and min/max values, respectively, before
-  converting. Clamping is equivalent to `clampedval = min(max(val, minvalue),
-  maxvalue)`.  This is much safer than `MapNone`.
+- `ClampMin(T, minvalue)`, `ClampMax(T, maxvalue)`, and
+  `ClampMinMax(T, minvalue, maxvalue)` create `MapInfo` objects that
+  clamp pixel values at the specified min, max, and min/max values,
+  respectively, before converting to type `T`. Clamping is equivalent
+  to `clampedval = min(max(val, minvalue), maxvalue)`.
 
 - `BitShift(T, N)` or `BitShift{T,N}()`, for scaling by bit-shift operators.
   `N` specifies the number of bits to right-shift by.  For example you could

--- a/doc/function_reference.md
+++ b/doc/function_reference.md
@@ -158,6 +158,15 @@ typeof( raw(img) )   # returns array with element type Uint8
 
 ```
 
+## separate
+```{.julia execute="false"}
+imgs = separate(img)
+```
+
+Separates the color channels of `img`, for
+example returning an `m-by-n-by-3` array from an `m-by-n` array of
+`RGB`.
+
 
 ## img[] (indexing)
 ```{.julia execute="false"}

--- a/src/Images.jl
+++ b/src/Images.jl
@@ -243,27 +243,4 @@ import FileIO: load, save
 @deprecate imwrite(img, filename; kwargs...) save(filename, img; kwargs...)
 export load, save
 
-
-
-import Base: scale, scale!  # delete when deprecations are removed
-@deprecate scaleminmax  ScaleMinMax
-@deprecate scaleminmax(img::AbstractArray, min::Real, max::Real)  ScaleMinMax(RGB24, img, min, max)
-@deprecate float32sc    float32
-@deprecate float64sc    float64
-@deprecate uint8sc      ufixed8sc
-@deprecate uint16sc(img)  ufixedsc(UFixed16, img)
-@deprecate ClipMin      ClampMin
-@deprecate ClipMax      ClampMax
-@deprecate ClipMinMax   ClampMinMax
-@deprecate climdefault(img) zero(eltype(img)), one(eltype(img))
-@deprecate ScaleMinMax{T<:Real}(img::AbstractArray{T}, mn, mx) ScaleMinMax(UFixed8, img, mn, mx)
-@deprecate ScaleMinMax{T<:Color}(img::AbstractArray{T}, mn, mx) ScaleMinMax(RGB{UFixed8}, img, mn, mx)
-@deprecate scaleinfo    mapinfo
-@deprecate scale(mapi::MapInfo, A) map(mapi, A)                # delete imports above when eliminated
-@deprecate scale!(dest, mapi::MapInfo, A) map!(mapi, dest, A)  #   "
-@deprecate copy(A::AbstractArray, B::AbstractArray) copyproperties(A, B)
-@deprecate share(A::AbstractArray, B::AbstractArray) shareproperties(A, B)
-
-const ScaleInfo = MapInfo  # can't deprecate types?
-
 end

--- a/src/Images.jl
+++ b/src/Images.jl
@@ -240,6 +240,41 @@ export # Deprecated exports
     scalesigned
 
 
+"""
+`Images` is a package for representing and processing images.
+
+Constructors, conversions, and traits:
+
+    - Construction: `Image`, `ImageCmap`, `grayim`, `colorim`, `convert`, `copyproperties`, `shareproperties`
+    - Traits: `colordim`, `colorspace`, `coords_spatial`, `data`, `isdirect`, `isxfirst`, `isyfirst`, `pixelspacing`, `properties`, `sdims`, `spacedirections`, `spatialorder`, `storageorder`, `timedim`
+    - Size-related traits: `height`, `nchannels`, `ncolorelem`, `nimages`, `size_spatial`, `width`, `widthheight`
+    - Trait assertions: `assert_2d`, `assert_scalar_color`, `assert_timedim_last`, `assert_xfirst`, `assert_yfirst`
+    - Indexing operations: `getindexim`, `sliceim`, `subim`
+    - Conversions: `convert`, `raw`, `reinterpret`, `separate`
+
+Contrast/coloration:
+
+    - `MapInfo`: `MapNone`, `BitShift`, `ClampMinMax`, `ScaleMinMax`, `ScaleAutoMinMax`, etc.
+    - `imadjustintensity`, `sc`, `imstretch`, `imcomplement`
+
+
+Algorithms:
+
+    - Reductions: `maxfinite`, `maxabsfinite`, `minfinite`, `meanfinite`, `sad`, `ssd`
+    - Resizing: `restrict`, `imresize` (not yet exported)
+    - Filtering: `imfilter`, `imfilter_fft`, `imfilter_gaussian`, `imfilter_LoG`, `imROF`, `ncc`, `padarray`
+    - Filtering kernels: `ando[345]`, `guassian2d`, `imaverage`, `imdog`, `imlaplacian`, `prewitt`, `sobel`
+    - Gradients: `backdiffx`, `backdiffy`, `forwarddiffx`, `forwarddiffy`, `imgradients`
+    - Edge detection: `imedge`, `imgradients`, `thin_edges`, `magnitude`, `phase`, `magnitudephase`, `orientation`
+    - Morphological operations: `dilate`, `erode`, `closing`, `opening`
+    - Connected components: `label_components`
+
+Test images and phantoms (see also TestImages.jl):
+
+    - `shepp_logan`
+"""
+Images
+
 import FileIO: load, save
 @deprecate imread(filename; kwargs...) load(filename; kwargs...)
 @deprecate imwrite(img, filename; kwargs...) save(filename, img; kwargs...)

--- a/src/Images.jl
+++ b/src/Images.jl
@@ -78,6 +78,7 @@ export # types
     ClampMax,
     ClampMinMax,
     Clamp,
+    Clamp01NaN,
     LabeledArray,
     MapInfo,
     MapNone,
@@ -85,6 +86,7 @@ export # types
     OverlayImage,
     ScaleAutoMinMax,
     ScaleMinMax,
+    ScaleMinMaxNaN,
     ScaleSigned,
     SliceData,
 

--- a/src/connected.jl
+++ b/src/connected.jl
@@ -1,5 +1,31 @@
 import Base.push!  # for DisjointMinSets
 
+"""
+```
+label = label_components(tf, [connectivity])
+label = label_components(tf, [region])
+```
+
+Find the connected components in a binary array `tf`. There are two forms that
+`connectivity` can take:
+
+- It can be a boolean array of the same dimensionality as `tf`, of size 1 or 3
+along each dimension. Each entry in the array determines whether a given
+neighbor is used for connectivity analyses. For example, `connectivity = trues(3,3)`
+would use 8-connectivity and test all pixels that touch the current one, even
+the corners.
+
+- You can provide a list indicating which dimensions are used to
+determine connectivity. For example, `region = [1,3]` would not test
+neighbors along dimension 2 for connectivity. This corresponds to just
+the nearest neighbors, i.e., 4-connectivity in 2d and 6-connectivity
+in 3d.
+
+The default is `region = 1:ndims(A)`.
+
+The output `label` is an integer array, where 0 is used for background
+pixels, and each connected region gets a different integer index.
+"""
 label_components(A, connectivity = 1:ndims(A), bkg = 0) = label_components!(zeros(Int, size(A)), A, connectivity, bkg)
 
 #### 4-connectivity in 2d, 6-connectivity in 3d, etc.

--- a/src/overlays.jl
+++ b/src/overlays.jl
@@ -1,4 +1,17 @@
 # An array type for colorized overlays of grayscale images
+"""
+```
+A = Overlay(channels, colors, clim)
+A = Overlay(channels, colors, mapi)
+```
+
+Create an `Overlay` array from grayscale channels.  `channels = (channel1,
+channel2, ...)`, `colors` is a vector or tuple of `Color`s, and `clim` is a
+vector or tuple of min/max values, e.g., `clim = ((min1,max1),(min2,max2),...)`.
+Alternatively, you can supply a list of `MapInfo` objects.
+
+See also: `OverlayImage`.
+"""
 immutable Overlay{T,N,NC,AT<:Tuple{Vararg{AbstractArray}},MITypes<:Tuple{Vararg{MapInfo}}} <: AbstractArray{RGB{T},N}
     channels::AT   # this holds the grayscale arrays
     colors::NTuple{NC,RGB{T}}
@@ -31,6 +44,7 @@ function Overlay(channels::Tuple{Vararg{AbstractArray}}, colors,
 end
 
 # Returns the overlay as an image, if possible
+"`OverlayImage` is identical to `Overlay`, except that it returns an Image."
 function OverlayImage(channels::Tuple{Vararg{AbstractArray}}, colors::Tuple{Vararg{Colorant}}, arg)
     ovr = Overlay(channels, colors, arg)
     local prop


### PR DESCRIPTION
```
julia> using Images

help?> separate
search: separate

  imgs = separate(img) separates the color channels of img, for example returning an m-by-n-by-3 array from an m-by-n array of RGB.
```

This is a WIP because there are still many files to go, but I wanted to post this here now because of one concern: presumably it would be best to generate the [function reference](http://timholy.github.io/Images.jl/function_reference.html) from the docstrings. I haven't plumbed into the guts of the new documentation system, so: does anyone know how to do this?

Particular CC to @rsrock, since he invested a lot in the github.io docs.