### PR TITLE
Fix tests for scalar index change on 0.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
     - osx
 julia:
     - 0.4
-#    - nightly
+    - nightly
 notifications:
     email: false
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,8 +2,8 @@ environment:
   matrix:
   - JULIAVERSION: "julialang/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
   - JULIAVERSION: "julialang/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
-#  - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
-#  - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
+  - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
+  - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
 
 branches:
   only:

--- a/test/core.jl
+++ b/test/core.jl
@@ -5,6 +5,8 @@ if testing_units
     using SIUnits, SIUnits.ShortUnits
 end
 
+const scalar_getindex_new = VERSION >= v"0.5.0-dev+1195"
+
 facts("Core") do
     a = rand(3,3)
     @inferred(Image(a))
@@ -201,12 +203,25 @@ facts("Core") do
         @fact ndims(s) --> 2
         @fact sdims(s) --> 2
         @fact size(s) --> (1,4)
-        @fact data(s) --> B[2, 1:4]
-        s = getindexim(img, 2, 1:4)
-        @fact ndims(s) --> 2
-        @fact sdims(s) --> 2
-        @fact size(s) --> (1,4)
-        @fact data(s) --> B[2, 1:4]
+        @fact data(s) --> sub(B, 2, 1:4)
+        if scalar_getindex_new
+            s = getindexim(img, 2, 1:4)
+            @fact ndims(s) --> 1
+            @fact sdims(s) --> 1
+            @fact size(s) --> (4,)
+            @fact data(s) --> B[2, 1:4]
+            s = getindexim(img, 2:2, 1:4)
+            @fact ndims(s) --> 2
+            @fact sdims(s) --> 2
+            @fact size(s) --> (1,4)
+            @fact data(s) --> B[2:2, 1:4]
+        else
+            s = getindexim(img, 2, 1:4)
+            @fact ndims(s) --> 2
+            @fact sdims(s) --> 2
+            @fact size(s) --> (1,4)
+            @fact data(s) --> B[2, 1:4]
+        end
         s = subim(img, 2, 1:4)
         @fact ndims(s) --> 2
         @fact sdims(s) --> 2
@@ -254,13 +269,13 @@ facts("Core") do
 
         s = permutedims(imgds, (3,1,2))
         @fact colordim(s) --> 1
-        ss = getindexim(s, 2, :, :)
+        ss = getindexim(s, 2:2, :, :)
         @fact colorspace(ss) --> "Unknown"
         @fact colordim(ss) --> 1
         sss = squeeze(ss, 1)
         @fact colorspace(ss) --> "Unknown"
         @fact colordim(sss) --> 0
-        ss = getindexim(imgds, 2, :, :)
+        ss = getindexim(imgds, 2:2, :, :)
         @fact colordim(ss) --> 3
         @fact spatialorder(ss) --> ["y", "x"]
         sss = squeeze(ss, 1)


### PR DESCRIPTION
This is the bare minimum change to make the tests pass. I think there shouldn't be much (any?) others that needs updating given `Images` mostly delegate to the base version for indexing.