### PR TITLE
ENH: Add morphological tophat, bothat, gradient, laplacian

### DIFF
--- a/doc/function_reference.md
+++ b/doc/function_reference.md
@@ -1048,6 +1048,42 @@ perform the `opening` and `closing` morphology operations. `opening` does first
 in the oposite way. The region parameter is passed to `erode` and `dilate` and describes
 the kernel size over which these operations are performed.
 
+## tophat
+```{.julia execute="false"}
+tophat(img, [region])
+```
+
+performs `top hat` of an image,
+which is defined as the image minus its morphological opening.
+The region parameter describes the kernel size over which these operations are performed.
+
+## bothat
+```{.julia execute="false"}
+bothat(img, [region])
+```
+
+performs `bottom hat` of an image,
+which is defined as its morphological closing minus the original image.
+The region parameter describes the kernel size over which these operations are performed.
+
+## morphogradient
+```{.julia execute="false"}
+morphogradient(img, [region])
+```
+
+returns morphological gradient of the image,
+which is the difference between the dilation and the erosion of a given image.
+The region parameter describes the kernel size over which these operations are performed.
+
+## morpholaplace
+```{.julia execute="false"}
+morpholaplace(img, [region])
+```
+
+performs `Morphological Laplacian` of an image,
+which is defined as the arithmetic difference between the internal and the external gradient.
+The region parameter describes the kernel size over which these operations are performed.
+
 ## label_components
 ```{.julia execute="false"}
 label_components(tf, [connectivity])

--- a/src/Images.jl
+++ b/src/Images.jl
@@ -180,6 +180,10 @@ export # types
     erode,
     opening,
     closing,
+    tophat,
+    bothat,
+    morphogradient,
+    morpholaplace,
     forwarddiffx,
     forwarddiffy,
     gaussian2d,
@@ -266,7 +270,7 @@ Algorithms:
     - Filtering kernels: `ando[345]`, `guassian2d`, `imaverage`, `imdog`, `imlaplacian`, `prewitt`, `sobel`
     - Gradients: `backdiffx`, `backdiffy`, `forwarddiffx`, `forwarddiffy`, `imgradients`
     - Edge detection: `imedge`, `imgradients`, `thin_edges`, `magnitude`, `phase`, `magnitudephase`, `orientation`
-    - Morphological operations: `dilate`, `erode`, `closing`, `opening`
+    - Morphological operations: `dilate`, `erode`, `closing`, `opening`, `tophat`, `bothat`, `morphogradient`, `morpholaplace`
     - Connected components: `label_components`
 
 Test images and phantoms (see also TestImages.jl):

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -1385,12 +1385,41 @@ end
 """
 opening(img::AbstractArray, region=coords_spatial(img)) = opening!(copy(img), region)
 opening!(img::AbstractArray, region=coords_spatial(img)) = dilate!(erode!(img, region),region)
+
 """
 `imgc = closing(img, [region])` performs the `closing` morphology operation, equivalent to `erode(dilate(img))`.
 `region` allows you to control the dimensions over which this operation is performed.
 """
 closing(img::AbstractArray, region=coords_spatial(img)) = closing!(copy(img), region)
 closing!(img::AbstractArray, region=coords_spatial(img)) = erode!(dilate!(img, region),region)
+
+"""
+`imgth = tophat(img, [region])` performs `top hat` of an image,
+which is defined as the image minus its morphological opening.
+`region` allows you to control the dimensions over which this operation is performed.
+"""
+tophat(img::AbstractArray, region=coords_spatial(img)) = img - opening(img, region)
+
+"""
+`imgbh = bothat(img, [region])` performs `bottom hat` of an image,
+which is defined as its morphological closing minus the original image.
+`region` allows you to control the dimensions over which this operation is performed.
+"""
+bothat(img::AbstractArray, region=coords_spatial(img)) = closing(img, region) - img
+
+"""
+`imgmg = morphogradient(img, [region])` returns morphological gradient of the image,
+which is the difference between the dilation and the erosion of a given image.
+`region` allows you to control the dimensions over which this operation is performed.
+"""
+morphogradient(img::AbstractArray, region=coords_spatial(img)) = dilate(img, region) - erode(img, region)
+
+"""
+`imgml = morpholaplace(img, [region])` performs `Morphological Laplacian` of an image,
+which is defined as the arithmetic difference between the internal and the external gradient.
+`region` allows you to control the dimensions over which this operation is performed.
+"""
+morpholaplace(img::AbstractArray, region=coords_spatial(img)) = dilate(img, region) + erode(img, region) - 2img
 
 extr(order::ForwardOrdering, x::Real, y::Real) = max(x,y)
 extr(order::ForwardOrdering, x::Real, y::Real, z::Real) = max(x,y,z)

--- a/test/algorithms.jl
+++ b/test/algorithms.jl
@@ -332,6 +332,51 @@ facts("Algorithms") do
         @fact Ac --> B
     end
 
+    context("Morphological Top-hat") do
+        A = zeros(13, 13)
+        A[2:3, 2:3] = 1
+        Ae = copy(A)
+        A[5:9, 5:9] = 1
+        Ao = Images.tophat(A)
+        @fact Ao --> Ae
+        Aoo = Images.tophat(Ae)
+        @fact Aoo --> Ae
+    end
+
+    context("Morphological Bottom-hat") do
+        A = ones(13, 13)
+        A[2:3, 2:3] = 0
+        Ae = 1 - copy(A)
+        A[5:9, 5:9] = 0
+        Ao = Images.bothat(A)
+        @fact Ao --> Ae
+    end
+
+    context("Morphological Gradient") do
+        A = zeros(13, 13)
+        A[5:9, 5:9] = 1
+        Ao = Images.morphogradient(A)
+        Ae = zeros(13, 13)
+        Ae[4:10, 4:10] = 1
+        Ae[6:8, 6:8] = 0
+        @fact Ao --> Ae
+        Aee = Images.dilate(A) - Images.erode(A)
+        @fact Aee --> Ae
+    end
+
+    context("Morphological Laplacian") do
+        A = zeros(13, 13)
+        A[5:9, 5:9] = 1
+        Ao = Images.morpholaplace(A)
+        Ae = zeros(13, 13)
+        Ae[4:10, 4:10] = 1
+        Ae[5:9, 5:9] = -1
+        Ae[6:8, 6:8] = 0
+        @fact Ao --> Ae
+        Aee = Images.dilate(A) + Images.erode(A) - 2A
+        @fact Aee --> Ae
+    end
+
     context("Label components") do
         A = [true  true  false true;
              true  false true  true]


### PR DESCRIPTION
In continuation with discussion from #402 

1. Added morphological tophat, bothat, gradient, laplacian functions
2. Basic test cases
3. Docs

I'm quite not sure if I've made proper/any use of copy, array properties to save memory or other optimizations for these functions. I thought, I'll push this is up and take feedback for the modifications/improvements if any needed. And, the documentation for these is a bit rusty too.