### PR TITLE
Fixed deprecation warning

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -1297,7 +1297,7 @@ end
 function ctranspose(img::AbstractImage)
     assert2d(img)
     s = coords_spatial(img)
-    p = [1:ndims(img)]
+    p = collect(1:ndims(img))
     p[s] = s[2:-1:1]
     permutedims(img, p)
 end


### PR DESCRIPTION
A very tiny change to fix the following warning...

```WARNING: [a] concatenation is deprecated; use collect(a) instead
 in depwarn at deprecated.jl:73
 in oldstyle_vcat_warning at ./abstractarray.jl:29
 in ctranspose at /home/hofmann/.julia/v0.4/Images/src/core.jl:1300```
