### PR TITLE
Rework writemime to use save(stream, img)

### DIFF
--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,2 +1,5 @@
 @osx TestImages
 FactCheck
+@windows ImageMagick
+@linux ImageMagick
+@osx QuartzImageIO

--- a/test/writemime.jl
+++ b/test/writemime.jl
@@ -9,7 +9,7 @@ facts("Writemime") do
         open(fn, "w") do file
             writemime(file, MIME("image/png"), grayim(A), minpixels=0, maxpixels=typemax(Int))
         end
-        b = load(fn)
+        b = convert(Image{Gray{U8}}, load(fn))
         @fact data(b) --> A
     end
     context("small images (expansion)") do
@@ -18,7 +18,7 @@ facts("Writemime") do
         open(fn, "w") do file
             writemime(file, MIME("image/png"), grayim(A), minpixels=5, maxpixels=typemax(Int))
         end
-        b = load(fn)
+        b = convert(Image{Gray{U8}}, load(fn))
         @fact data(b) --> A[[1,1,2,2],[1,1,2,2]]
     end
     context("big images (use of restrict)") do
@@ -28,7 +28,7 @@ facts("Writemime") do
         open(fn, "w") do file
             writemime(file, MIME("image/png"), grayim(A), minpixels=0, maxpixels=5)
         end
-        b = load(fn)
+        b = convert(Image{Gray{U8}}, load(fn))
         @fact data(b) --> convert(Array{U8}, Ar)
         # a genuinely big image (tests the defaults)
         abig = grayim(rand(UInt8, 1024, 1023))
@@ -36,7 +36,7 @@ facts("Writemime") do
         open(fn, "w") do file
             writemime(file, MIME("image/png"), abig, maxpixels=10^6)
         end
-        b = load(fn)
+        b = convert(Image{Gray{U8}}, load(fn))
         abigui = convert(Array{UFixed8,2}, data(restrict(abig, (1,2))))
         @fact data(b) --> convert(Array{UFixed8,2}, data(restrict(abig, (1,2))))
     end

--- a/test/writemime.jl
+++ b/test/writemime.jl
@@ -3,7 +3,25 @@ facts("Writemime") do
     if !isdir(workdir)
         mkdir(workdir)
     end
-    context("use of restrict") do
+    context("no compression or expansion") do
+        A = U8[0.01 0.99; 0.25 0.75]
+        fn = joinpath(workdir, "writemime.png")
+        open(fn, "w") do file
+            writemime(file, MIME("image/png"), grayim(A), minpixels=0, maxpixels=typemax(Int))
+        end
+        b = load(fn)
+        @fact data(b) --> A
+    end
+    context("small images (expansion)") do
+        A = U8[0.01 0.99; 0.25 0.75]
+        fn = joinpath(workdir, "writemime.png")
+        open(fn, "w") do file
+            writemime(file, MIME("image/png"), grayim(A), minpixels=5, maxpixels=typemax(Int))
+        end
+        b = load(fn)
+        @fact data(b) --> A[[1,1,2,2],[1,1,2,2]]
+    end
+    context("big images (use of restrict)") do
         abig = grayim(rand(UInt8, 1024, 1023))
         fn = joinpath(workdir, "big.png")
         open(fn, "w") do file

--- a/test/writemime.jl
+++ b/test/writemime.jl
@@ -1,6 +1,5 @@
-writemime_(io::IO, ::MIME"image/png", img::AbstractImage) = serialize(io, map(Images.mapinfo_writemime(img), img))
 facts("Writemime") do
-	workdir = joinpath(tempdir(), "Images")
+    workdir = joinpath(tempdir(), "Images")
     if !isdir(workdir)
         mkdir(workdir)
     end
@@ -10,9 +9,7 @@ facts("Writemime") do
         open(fn, "w") do file
             writemime(file, MIME("image/png"), abig, maxpixels=10^6)
         end
-        b = open(fn, "r") do io 
-        	deserialize(io)
-        end
+        b = load(fn)
         abigui = convert(Array{UFixed8,2}, data(restrict(abig, (1,2))))
         @fact data(b) --> convert(Array{UFixed8,2}, data(restrict(abig, (1,2))))
     end

--- a/test/writemime.jl
+++ b/test/writemime.jl
@@ -22,6 +22,15 @@ facts("Writemime") do
         @fact data(b) --> A[[1,1,2,2],[1,1,2,2]]
     end
     context("big images (use of restrict)") do
+        A = U8[0.01 0.4 0.99; 0.25 0.8 0.75; 0.6 0.2 0.0]
+        Ar = restrict(A)
+        fn = joinpath(workdir, "writemime.png")
+        open(fn, "w") do file
+            writemime(file, MIME("image/png"), grayim(A), minpixels=0, maxpixels=5)
+        end
+        b = load(fn)
+        @fact data(b) --> convert(Array{U8}, Ar)
+        # a genuinely big image (tests the defaults)
         abig = grayim(rand(UInt8, 1024, 1023))
         fn = joinpath(workdir, "big.png")
         open(fn, "w") do file


### PR DESCRIPTION
This reworks `writemime` to address https://github.com/timholy/TestImages.jl/issues/11, leveraging FileIO's `save(stream, img)` to avoid the need for a `writemime_` method exported by FileIO. Requires https://github.com/JuliaIO/ImageMagick.jl/pull/29. (Come to think about it, this PR will fail Travis until we tag a new version of ImageMagick. I'll do that once https://github.com/JuliaIO/ImageMagick.jl/pull/30 merges.) CC @SimonDanisch, @tlnagy, @Evizero.

See also https://github.com/JuliaIO/QuartzImageIO.jl/pull/16
