### PR TITLE
Fix import (Base.take) error on v0.5-devel

### DIFF
--- a/src/Images.jl
+++ b/src/Images.jl
@@ -2,6 +2,7 @@ __precompile__(true)
 
 module Images
 
+VERSION >= v"0.4.0" && import Base.take
 import Base.Order: Ordering, ForwardOrdering, ReverseOrdering
 import Base: ==, .==, +, -, *, /, .+, .-, .*, ./, .^, .<, .>
 import Base: atan2, clamp, convert, copy, copy!, ctranspose, delete!, done,


### PR DESCRIPTION
On 0.5.0-dev+3012 (commit 93cb2ae), Images.jl fails to load without importing Base.take into the module. This shouldn't break anything on v0.4.0+, but Base.take doesn't exist in v0.3 (at least according to the documentation here: http://docs.julialang.org/en/release-0.3/search/?q=Base.take&check_keywords=yes&area=default), so protecting against a failure there, as well.

Best,
Rob