### PR TITLE
Minor doc fix for `imstretch`.

### DIFF
--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -1342,7 +1342,7 @@ end
 `imgs = imstretch(img, m, slope)` enhances or reduces (for
 slope > 1 or < 1, respectively) the contrast near saturation (0 and 1). This is
 essentially a symmetric gamma-correction. For a pixel of brightness `p`, the new
-intensity is `1/(1+m/(p+eps)^slope)`.
+intensity is `1/(1+(m/(p+eps))^slope)`.
 
 This assumes the input `img` has intensities between 0 and 1.
 """


### PR DESCRIPTION
This makes the documentation correspond to the code: `m` is taken to the power too.

Since I wasn't sure whether the comment or the code was right, I tried to find a reference for this formula, but my google-fu fails me. Is there a reference? If you link it, I could add it to this PR before merge.