### PR TITLE
Add flipdim with dimension as string parameter

### DIFF
--- a/src/Images.jl
+++ b/src/Images.jl
@@ -174,6 +174,11 @@ export # types
     ufixed8sc,
     ufixedsc,
 
+    # flip dimensions
+    flipx,
+    flipy,
+    flipz,
+
     # algorithms
     ando3,
     ando4,

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -765,6 +765,14 @@ function imfilter_fft_inseparable{T<:Real,K,N}(img::AbstractArray{T,N}, kern::Ab
     out
 end
 
+# flips the dimension specified by name instead of index
+# it is thus independent of the storage order
+Base.flipdim(img::AbstractImage, dimname::ASCIIString) = shareproperties(img, flipdim(data(img), dimindex(img, dimname)))
+
+flipx(img::AbstractImage) = flipdim(img, "x")
+flipy(img::AbstractImage) = flipdim(img, "y")
+flipz(img::AbstractImage) = flipdim(img, "z")
+
 # Generalization of rot180
 @generated function reflect{T,N}(A::AbstractArray{T,N})
     quote

--- a/test/algorithms.jl
+++ b/test/algorithms.jl
@@ -7,6 +7,28 @@ facts("Algorithms") do
     approx_equal(ar, v) = all(abs(ar.-v) .< sqrt(eps(v)))
     approx_equal(ar::Images.AbstractImage, v) = approx_equal(Images.data(ar), v)
 
+	context("Flip dimensions") do
+		A = UInt8[200 150; 50 1]
+		img_x = grayim(A)
+		img_y = permutedims(img_x, [2, 1])
+
+		@fact raw(flipdim(img_x, "x")) --> raw(flipdim(img_x, 1))
+		@fact raw(flipdim(img_x, "x")) --> flipdim(A, 1)
+		@fact raw(flipdim(img_y, "x")) --> raw(flipdim(img_y, 2))
+		@fact raw(flipdim(img_y, "x")) --> flipdim(A', 2)
+
+		@fact raw(flipdim(img_x, "y")) --> raw(flipdim(img_x, 2))
+		@fact raw(flipdim(img_x, "y")) --> flipdim(A, 2)
+		@fact raw(flipdim(img_y, "y")) --> raw(flipdim(img_y, 1))
+		@fact raw(flipdim(img_y, "y")) --> flipdim(A', 1)
+
+		@fact raw(flipx(img_x)) --> raw(flipdim(img_x, "x"))
+		@fact raw(flipx(img_y)) --> raw(flipdim(img_y, "x"))
+
+		@fact raw(flipy(img_x)) --> raw(flipdim(img_x, "y"))
+		@fact raw(flipy(img_y)) --> raw(flipdim(img_y, "y"))
+	end
+
     context("Arithmetic") do
         img = convert(Images.Image, zeros(3,3))
         img2 = (img .+ 3)/2


### PR DESCRIPTION
Allows `Base.flipdim` to be called with a string parameter denoting the dimension. Tests are included

For example, the following code flips the x dimension, independent of the storage order:

```julia
img = grayimg(UInt8[200 150; 50 1])
img2 = flipdim(img, "x")
```

Alternatively, additional shortcut functions are provided for the three most common spatial dimensions x, y, and z. These shortcut functions are called `flipx`, `flipy`, and `flipz` respectively.

For example, the following code is equivalent to the example provided above:

```julia
img = grayimg(UInt8[200 150; 50 1])
img2 = flipx(img)
```