### PR TITLE
Fix some conversion bugs & rebase on ccolor

### DIFF
--- a/test/core.jl
+++ b/test/core.jl
@@ -435,6 +435,11 @@ facts("Core") do
         @fact data(imgray) --> reinterpret(Gray{UFixed8}, [0x01 0x02; 0x03 0x04])
         @fact eltype(convert(Image{HSV{Float32}}, imrgb8)) --> HSV{Float32}
         @fact eltype(convert(Image{HSV}, float32(imrgb8))) --> HSV{Float32}
+
+        @fact eltype(convert(Array{Gray}, imrgb8)) --> Gray{U8}
+        @fact eltype(convert(Image{Gray}, imrgb8)) --> Gray{U8}
+        @fact eltype(convert(Array{Gray}, data(imrgb8))) --> Gray{U8}
+        @fact eltype(convert(Image{Gray}, data(imrgb8))) --> Gray{U8}
         # Issue 232
         local img = Image(reinterpret(Gray{UFixed16}, rand(UInt16, 5, 5)))
         imgs = subim(img, :, :)


### PR DESCRIPTION
In the course of considering #458, I noticed some missing methods and errors in converting to grayscale. I took the opportunity to rebase some of the conversion methods on `ccolor` from ColorTypes; this greatly simplifies the selection of a concrete color type. (There are probably more places where this could be leveraged.)
