### PR TITLE
Adds Histogram Function

### DIFF
--- a/docs/src/function_reference.md
+++ b/docs/src/function_reference.md
@@ -269,6 +269,11 @@ include the following functions:
     findlocalmaxima
     findlocalminima
 
+# Exposure
+
+    {docs}
+    imhist
+
 # Filtering kernels
 
     {docs}

--- a/src/Images.jl
+++ b/src/Images.jl
@@ -214,6 +214,7 @@ export # types
     findlocalminima,
     imgaussiannoise,
     imgradients,
+    imhist,
     imlaplacian,
     imlineardiffusion,
     imlog,
@@ -277,6 +278,7 @@ Algorithms:
     - Resizing: `restrict`, `imresize` (not yet exported)
     - Filtering: `imfilter`, `imfilter_fft`, `imfilter_gaussian`, `imfilter_LoG`, `imROF`, `ncc`, `padarray`
     - Filtering kernels: `ando[345]`, `guassian2d`, `imaverage`, `imdog`, `imlaplacian`, `prewitt`, `sobel`
+    - Exposure : `imhist`
     - Gradients: `backdiffx`, `backdiffy`, `forwarddiffx`, `forwarddiffy`, `imgradients`
     - Edge detection: `imedge`, `imgradients`, `thin_edges`, `magnitude`, `phase`, `magnitudephase`, `orientation`
     - Corner detection: `imcorner`

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -1197,6 +1197,42 @@ if isdefined(:restrict)
 end
 
 """
+```
+range, histogram = imhist(img, nbins)
+range, histogram = imhist(img, nbins, minval, maxval)
+```
+
+Generates a histogram for the image over nbins spread between (minval, maxval). If minval and maxval are not given, then the
+minimum and maximum values present in the image are taken.
+"""
+
+imhist{T<:Colorant}(img::AbstractArray{T}, nbins=400) = imhist(convert(Array{Gray}, data(img)), nbins)
+imhist{T<:Colorant}(img::AbstractArray{T}, nbins, minval, maxval) = imhist(convert(Array{Gray}, data(img)), nbins, minval, maxval)
+
+function imhist{T<:Union{Gray,Number}}(img::AbstractArray{T}, nbins = 400)
+    minval = minfinite(img)
+    maxval = maxfinite(img)
+    imhist(img, nbins, minval, maxval)
+end
+
+function imhist{T<:Union{Gray,Number}}(img::AbstractArray{T}, nbins, minval::T, maxval::T)
+    bins = minval:(maxval-minval+1)/(nbins):maxval
+    histogram = zeros(Integer,nbins+2)
+    for val in img
+        if val>maxval
+            histogram[end] += 1
+            continue
+        end
+        index = searchsortedlast(bins, val)
+        histogram[index+1] += 1
+    end
+    bins, histogram
+end
+
+imhist{T<:Union{Gray,Number}}(img::AbstractArray{T}, nbins, minval, maxval) = imhist(img, nbins, convert(T, minval), convert(T, maxval))
+
+
+"""
 `imgr = restrict(img[, region])` performs two-fold reduction in size
 along the dimensions listed in `region`, or all spatial coordinates if
 `region` is not specified.  It anti-aliases the image as it goes, so

--- a/test/algorithms.jl
+++ b/test/algorithms.jl
@@ -158,6 +158,24 @@ facts("Algorithms") do
         @fact img2 --> roughly(reinterpret(Float32, img))
     end
 
+    context("Exposure") do
+        img = 1:1:10
+        bins, hist = Images.imhist(img, 10)
+        @fact bins --> 1.0:1.0:10.0
+        @fact hist --> [0,1, 1, 1, 1, 1, 1, 1, 1, 1, 1,0]
+        bins, hist = Images.imhist(img, 5, 2, 6)
+        @fact bins --> 2.0:1.0:6.0
+        @fact hist --> [1, 1, 1, 1, 1, 1, 4]
+
+        img = reshape(0:1:99, 10, 10)
+        bins, hist = Images.imhist(img, 10)
+        @fact bins --> 0.0:10.0:90.0
+        @fact hist --> [0, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 0]
+        bins, hist = Images.imhist(img, 7, 25, 59)
+        @fact bins --> 25.0:5.0:55.0
+        @fact hist --> [25, 5, 5, 5, 5, 5, 5, 5, 40]
+    end
+
     context("Array padding") do
         A = [1 2; 3 4]
         @fact Images.padindexes(A, 1, 0, 0, "replicate") --> [1,2]


### PR DESCRIPTION
@timholy I found your version to be better than what I had earlier. Just one doubt : As you said, the two extra bins will create an issue for the histeq function. I could hard code that function to ignore those two bins but I dont know if that would be the correct way to do this. I do not want to remove the two a bins too since it gives a very nice representation of the image if (minval, maxval) does not cover the entire range. I feel we can do this : Take a (minval, maxval) range for the histeq function as well and then equalise only in that range. The default will be the entire range. This way we can have both the things. Does this look fine?