### PR TITLE
Use showcompact instead of print for metadata

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -1417,9 +1417,13 @@ end
 printdictval(io::IO, v) = print(io, v)
 function printdictval(io::IO, v::Vector)
     for i = 1:length(v)
-        print(io, " ", v[i])
+        print(io, " ")
+        showdictelem(io, v[i])
     end
 end
+
+showdictelem(io::IO, v::AbstractString) = print(io, v)
+showdictelem(io::IO, v) = showcompact(io, v)
 
 # Support indexing via
 #    img["t", 32, "x", 100:400]


### PR DESCRIPTION
See #484 

basically, for vectors it still prints Strings using `print` while using `showcompact` for other types