### PR TITLE
Fix histogram deprecation and behavior

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -7,3 +7,4 @@ Zlib
 Graphics 0.1
 FileIO
 Compat 0.7.15
+StatsBase   # for histrange

--- a/src/Images.jl
+++ b/src/Images.jl
@@ -14,7 +14,7 @@ import Base: atan2, clamp, convert, copy, copy!, ctranspose, delete!, done,
              start, strides, sub, sum, write, writemime, zero
 # "deprecated imports" are below
 
-using Colors, ColorVectorSpace, FixedPointNumbers, FileIO
+using Colors, ColorVectorSpace, FixedPointNumbers, FileIO, StatsBase
 import Colors: Fractional, red, green, blue
 typealias AbstractGray{T}                    Color{T,1}
 typealias TransparentRGB{C<:AbstractRGB,T}   TransparentColor{C,T,4}

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -149,24 +149,25 @@ The base b of the logarithm (a.k.a. entropy unit) is one of the following:
   `:hartley` (log base 10)
 """
 function entropy(img::AbstractArray; kind=:shannon)
-  logᵦ = _log(kind)
+    logᵦ = _log(kind)
 
-  _, counts = hist(img[:], 256)
-  p = counts / length(img)
-  logp = logᵦ(p)
+    hist = StatsBase.fit(Histogram, vec(img), nbins=256)
+    counts = hist.weights
+    p = counts / length(img)
+    logp = logᵦ(p)
 
-  # take care of empty bins
-  logp[isinf(logp)] = 0
+    # take care of empty bins
+    logp[isinf(logp)] = 0
 
-  -sum(p.*logp)
+    -sum(p.*logp)
 end
 
 function entropy(img::AbstractArray{Bool}; kind=:shannon)
-  logᵦ = _log(kind)
+    logᵦ = _log(kind)
 
-  p = sum(img) / length(img)
+    p = sum(img) / length(img)
 
-  (0 < p < 1) ? - p*logᵦ(p) - (1-p)*logᵦ(1-p) : zero(p)
+    (0 < p < 1) ? - p*logᵦ(p) - (1-p)*logᵦ(1-p) : zero(p)
 end
 
 entropy{C<:AbstractGray}(img::AbstractArray{C}; kind=:shannon) = entropy(raw(img), kind=kind)

--- a/src/overlays.jl
+++ b/src/overlays.jl
@@ -13,9 +13,9 @@ Alternatively, you can supply a list of `MapInfo` objects.
 
 See also: `OverlayImage`.
 """
-immutable Overlay{T,N,NC,AT<:Tuple{Vararg{AbstractArray}},MITypes<:Tuple{Vararg{MapInfo}}} <: AbstractArray{RGB{T},N}
+immutable Overlay{C<:RGB,N,NC,AT<:Tuple{Vararg{AbstractArray}},MITypes<:Tuple{Vararg{MapInfo}}} <: AbstractArray{C,N}
     channels::AT   # this holds the grayscale arrays
-    colors::NTuple{NC,RGB{T}}
+    colors::NTuple{NC,C}
     mapi::MITypes
 
     function Overlay(channels::Tuple{Vararg{AbstractArray}}, colors, mapi::Tuple{Vararg{MapInfo}})
@@ -29,8 +29,8 @@ immutable Overlay{T,N,NC,AT<:Tuple{Vararg{AbstractArray}},MITypes<:Tuple{Vararg{
 end
 Overlay(channels::Tuple{Vararg{AbstractArray}}, colors::AbstractVector, mapi::Tuple{Vararg{MapInfo}}) =
     Overlay(channels,tuple(colors...),mapi)
-Overlay{NC,T}(channels::Tuple{Vararg{AbstractArray}}, colors::NTuple{NC,RGB{T}}, mapi::Tuple{Vararg{MapInfo}}) =
-    Overlay{T,ndims(channels[1]),NC,typeof(channels),typeof(mapi)}(channels,colors,mapi)
+Overlay{NC,C<:RGB}(channels::Tuple{Vararg{AbstractArray}}, colors::NTuple{NC,C}, mapi::Tuple{Vararg{MapInfo}}) =
+    Overlay{C,ndims(channels[1]),NC,typeof(channels),typeof(mapi)}(channels,colors,mapi)
 
 function Overlay(channels::Tuple{Vararg{AbstractArray}}, colors,
                  clim = ntuple(i->(zero(eltype(channels[i])), one(eltype(channels[i]))), length(channels)))
@@ -89,17 +89,11 @@ setindex!(O::Overlay, val, I::Real...) = error("Overlays are read-only. Convert 
 
 
 #### Other Overlay support functions ####
-eltype{T}(o::Overlay{T}) = RGB{T}
 length(o::Overlay) = isempty(o.channels) ? 0 : length(o.channels[1])
 size(o::Overlay) = isempty(o.channels) ? (0,) : size(o.channels[1])
 size(o::Overlay, d::Integer) = isempty(o.channels) ? 0 : size(o.channels[1],d)
 nchannels(o::Overlay) = length(o.channels)
 
-similar(o::Overlay) = Array(eltype(o), size(o))
-similar(o::Overlay, ::NTuple{0}) = Array(eltype(o), size(o))
-similar{T}(o::Overlay, ::Type{T}) = Array(T, size(o))
-similar{T}(o::Overlay, ::Type{T}, sz::Int64) = Array(T, sz)
-similar{T}(o::Overlay, ::Type{T}, sz::Int64...) = Array(T, sz)
-similar{T}(o::Overlay, ::Type{T}, sz) = Array(T, sz)
+similar{T}(o::Overlay, ::Type{T}, sz::Dims) = Array(T, sz)
 
 showcompact(io::IO, o::Overlay) = print(io, summary(o), " with colors ", o.colors)

--- a/test/algorithms.jl
+++ b/test/algorithms.jl
@@ -159,21 +159,36 @@ facts("Algorithms") do
     end
 
     context("Exposure") do
-        img = 1:1:10
+        # Many of these test integer values, but of course most images
+        # should have pixel values between 0 and 1.  Still, it doesn't
+        # hurt to get the integer case right too.
+        img = 1:10
         bins, hist = Images.imhist(img, 10)
-        @fact bins --> 1.0:1.0:10.0
+        @fact length(hist) --> length(bins)+1
+        @fact bins --> 1.0:1.0:11.0
         @fact hist --> [0,1, 1, 1, 1, 1, 1, 1, 1, 1, 1,0]
         bins, hist = Images.imhist(img, 5, 2, 6)
-        @fact bins --> 2.0:1.0:6.0
+        @fact length(hist) --> length(bins)+1
+        @fact bins --> 2.0:1.0:7.0
         @fact hist --> [1, 1, 1, 1, 1, 1, 4]
 
-        img = reshape(0:1:99, 10, 10)
+        img = reshape(0:99, 10, 10)
         bins, hist = Images.imhist(img, 10)
-        @fact bins --> 0.0:10.0:90.0
+        @fact length(hist) --> length(bins)+1
+        @fact bins --> 0.0:10.0:100.0
         @fact hist --> [0, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 0]
         bins, hist = Images.imhist(img, 7, 25, 59)
-        @fact bins --> 25.0:5.0:55.0
+        @fact length(hist) --> length(bins)+1
+        @fact bins --> 25.0:5.0:60.0
         @fact hist --> [25, 5, 5, 5, 5, 5, 5, 5, 40]
+
+        # Test the more typical case
+        img = reinterpret(Gray{U8}, [0x20,0x40,0x80,0xd0])
+        @fact imhist(img, 5) --> (0.0:0.2:1.0,[0,1,1,1,0,1,0])
+        img = reinterpret(Gray{U8}, [0x00,0x40,0x80,0xd0])
+        @fact imhist(img, 5) --> (0.0:0.2:1.0,[0,1,1,1,0,1,0])
+        img = reinterpret(Gray{U8}, [0x00,0x40,0x80,0xff])
+        @fact imhist(img, 6) --> (0.0:0.2:1.2,[0,1,1,1,0,0,1,0])
     end
 
     context("Array padding") do

--- a/test/overlays.jl
+++ b/test/overlays.jl
@@ -29,10 +29,10 @@ facts("Overlay") do
     end
 
     context("Two") do
-        local ovr = Images.Overlay((gray, 0*gray), (RGB{UFixed8}(1, 0, 1), RGB{UFixed8}(0, 1, 0)), ((0, 1), (0, 1)))
+        ovr = Images.Overlay((gray, 0*gray), (RGB{UFixed8}(1, 0, 1), RGB{UFixed8}(0, 1, 0)), ((0, 1), (0, 1)))
         @fact eltype(ovr) --> RGB{UFixed8}
         s = similar(ovr)
-        @fact isa(s, Vector{RGB{UFixed8}}) --> true
+        @fact typeof(s) --> Vector{RGB{UFixed8}}
         @fact length(s) --> 5
         s = similar(ovr, RGB{Float32})
         @fact isa(s, Vector{RGB{Float32}}) --> true


### PR DESCRIPTION
This makes subtle changes in how the histogram is computed. The key change is to clarify the meaning of the return values (see the changes to the docstring for a description), which necessitated changing some of the tests. While I understand that some of the return values may be worse from a DWIM perspective, from a mathematical standpoint this is more consistent.

Incidentally this fixes #490, and also some other problems on julia-0.5. It won't pass tests, however, until https://github.com/JuliaStats/StatsBase.jl/pull/166 is merged and tagged.
