### PR TITLE
Delete "colorspace" property when converting to Image{Gray}. Fixes #497.

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -369,8 +369,9 @@ function convert(::Type{Image}, img::ImageCmap)
 end
 
 convert{C<:Colorant}(::Type{Image{C}}, img::Image{C}) = img
-convert{Cdest<:Colorant,Csrc<:Colorant}(::Type{Image{Cdest}}, img::Image{Csrc}) = copyproperties(img, convert(Array{ccolor(Cdest,Csrc)}, data(img)))
-convert{Cdest<:Colorant,Csrc<:Colorant}(::Type{Image{Cdest}}, img::AbstractArray{Csrc}) = Image(convert(Array{Cdest}, data(img)), properties(img))
+convert{Cdest<:Colorant,Csrc<:Colorant}(::Type{Image{Cdest}}, img::Image{Csrc}) = deletecs!(copyproperties(img, convert(Array{ccolor(Cdest,Csrc)}, data(img))))
+convert{Cdest<:Colorant,Csrc<:Colorant}(::Type{Image{Cdest}}, img::AbstractArray{Csrc}) = deletecs!(Image(convert(Array{Cdest}, data(img)), properties(img)))
+deletecs!(img) = (delete!(img, "colorspace"); img)
 
 # Convert an Image to an array. We convert the image into the canonical storage order convention for arrays.
 # We restrict this to 2d images because for plain arrays this convention exists only for 2d.

--- a/test/core.jl
+++ b/test/core.jl
@@ -465,5 +465,11 @@ facts("Core") do
             @fact typeof(raw(imgdata)) --> typeof(imgdata)  # check array fallback
             @fact all(raw(imgdata) .== imgdata) --> true
         end
+        # Issue #497
+        let img = colorim(rand(3, 5, 5))
+            img["colorspace"] = "sRGB"
+            imgg = convert(Image{Gray}, img)
+            @fact haskey(imgg, "colorspace") --> false
+        end
     end
 end


### PR DESCRIPTION
See #497.