### PR TITLE
Fixes Issues with Histeq, changes the dtype argument.

### DIFF
--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -1326,6 +1326,7 @@ function histeq{T<:Union{Gray,Number}}(img::AbstractArray{T}, nbins::Int, minval
     hist_equalised_img = [max(1,Int(ceil((x-minval)*cdf_length/(maxval-minval)))) for x in img]
     hist_equalised_img = [minval + ((cdf[x]-cdf[1])*(maxval-minval)/(cdf[end]-cdf[1])) for x in hist_equalised_img]
     hist_equalised_img = reshape(hist_equalised_img, img_shape)
+    hist_equalised_img = convert(Array{T}, hist_equalised_img)
     hist_equalised_img
 end
 


### PR DESCRIPTION
- Changed dtype argument
- Fixed #503 
- Fixed #502 

Some unsolved issues : 

- #504 
- #503 (The convert(Array{GrayA}, img) method is not working. The returned datatype for transaparent images is ```Array{Any}``` instead of ```Array{Gray}```. This causes an error while saving the image.)

```julia
julia> img = testimage("house")
GrayA Images.Image with:
  data: 512×512 Array{ColorTypes.GrayA{FixedPointNumbers.UFixed{UInt8,8}},2}
  properties:
    colorspace: Gray
    spatialorder:  x y

julia> h=Images.histeq(img, 1000)
Gray Images.Image with:
  data: 512×512 Array{Any,2}
  properties:
    colorspace: Gray
    spatialorder:  x y

julia> save("test.jpg", h)
WARNING: MethodError(ImageMagick.mapinfo,(
Gray Images.Image with:
  data: 512×512 Array{Any,2}
  properties:
    colorspace: Gray
    spatialorder:  x y,))
 in save_ at /home/jarvis/.julia/v0.5/ImageMagick/src/ImageMagick.jl:158 [inlined] (repeats 2 times)
 in #save#5(::Array{Any,1}, ::Function, ::FileIO.File{FileIO.DataFormat{:JPEG}}, ::Images.Image{Any,2,Array{Any,2}}, ::Vararg{Images.Image{Any,2,Array{Any,2}},N}) at /home/jarvis/.julia/v0.5/ImageMagick/src/ImageMagick.jl:68
 in save(::FileIO.File{FileIO.DataFormat{:JPEG}}, ::Images.Image{Any,2,Array{Any,2}}, ::Vararg{Images.Image{Any,2,Array{Any,2}},N}) at /home/jarvis/.julia/v0.5/ImageMagick/src/ImageMagick.jl:68
 in #save#18(::Array{Any,1}, ::Function, ::FileIO.File{FileIO.DataFormat{:JPEG}}, ::Images.Image{Any,2,Array{Any,2}}, ::Vararg{Images.Image{Any,2,Array{Any,2}},N}) at /home/jarvis/.julia/v0.5/FileIO/src/loadsave.jl:95
 in save(::FileIO.File{FileIO.DataFormat{:JPEG}}, ::Images.Image{Any,2,Array{Any,2}}) at /home/jarvis/.julia/v0.5/FileIO/src/loadsave.jl:89
 in #save#14(::Array{Any,1}, ::Function, ::String, ::Images.Image{Any,2,Array{Any,2}}, ::Vararg{Images.Image{Any,2,Array{Any,2}},N}) at /home/jarvis/.julia/v0.5/FileIO/src/loadsave.jl:51
 in save(::String, ::Images.Image{Any,2,Array{Any,2}}) at /home/jarvis/.julia/v0.5/FileIO/src/loadsave.jl:51
 in eval(::Module, ::Any) at ./boot.jl:225
 in macro expansion at ./REPL.jl:92 [inlined]
 in (::Base.REPL.##1#2{Base.REPL.REPLBackend})() at ./event.jl:46
ERROR: MethodError: no method matching mapinfo(::Images.Image{Any,2,Array{Any,2}})
 in save_ at /home/jarvis/.julia/v0.5/ImageMagick/src/ImageMagick.jl:158 [inlined] (repeats 2 times)
 in #save#5(::Array{Any,1}, ::Function, ::FileIO.File{FileIO.DataFormat{:JPEG}}, ::Images.Image{Any,2,Array{Any,2}}, ::Vararg{Images.Image{Any,2,Array{Any,2}},N}) at /home/jarvis/.julia/v0.5/ImageMagick/src/ImageMagick.jl:68
 in save(::FileIO.File{FileIO.DataFormat{:JPEG}}, ::Images.Image{Any,2,Array{Any,2}}, ::Vararg{Images.Image{Any,2,Array{Any,2}},N}) at /home/jarvis/.julia/v0.5/ImageMagick/src/ImageMagick.jl:68
 in #save#18(::Array{Any,1}, ::Function, ::FileIO.File{FileIO.DataFormat{:JPEG}}, ::Images.Image{Any,2,Array{Any,2}}, ::Vararg{Images.Image{Any,2,Array{Any,2}},N}) at /home/jarvis/.julia/v0.5/FileIO/src/loadsave.jl:95
 in save(::FileIO.File{FileIO.DataFormat{:JPEG}}, ::Images.Image{Any,2,Array{Any,2}}) at /home/jarvis/.julia/v0.5/FileIO/src/loadsave.jl:89
 in #save#14(::Array{Any,1}, ::Function, ::String, ::Images.Image{Any,2,Array{Any,2}}, ::Vararg{Images.Image{Any,2,Array{Any,2}},N}) at /home/jarvis/.julia/v0.5/FileIO/src/loadsave.jl:51
 in save(::String, ::Images.Image{Any,2,Array{Any,2}}) at /home/jarvis/.julia/v0.5/FileIO/src/loadsave.jl:51
 in eval(::Module, ::Any) at ./boot.jl:225
 in macro expansion at ./REPL.jl:92 [inlined]
 in (::Base.REPL.##1#2{Base.REPL.REPLBackend})() at ./event.jl:46

```