### PR TITLE
Fix writemime deprecation

### DIFF
--- a/src/Images.jl
+++ b/src/Images.jl
@@ -11,7 +11,7 @@ import Base: atan2, clamp, convert, copy, copy!, ctranspose, delete!, done,
              minimum, next, ndims, one, parent, permutedims, reinterpret,
              reshape, resize!,
              setindex!, show, showcompact, similar, size, slice, sqrt, squeeze,
-             start, strides, sub, sum, write, writemime, zero
+             start, strides, sub, sum, write, zero
 if VERSION < v"0.5.0-dev+4490"
     import Base: float32, float64
 else

--- a/src/core.jl
+++ b/src/core.jl
@@ -731,9 +731,9 @@ function showim(io::IO, img::AbstractImageIndexed)
     showdictlines(io, img.properties, get(img, "suppress", emptyset))
 end
 show(io::IO, img::AbstractImageDirect) = showim(io, img)
-writemime(io::IO, ::MIME"text/plain", img::AbstractImageDirect) = showim(io, img)
+@compat Base.show(io::IO, ::MIME"text/plain", img::AbstractImageDirect) = showim(io, img)
 show(io::IO, img::AbstractImageIndexed) = showim(io, img)
-writemime(io::IO, ::MIME"text/plain", img::AbstractImageIndexed) = showim(io, img)
+@compat Base.show(io::IO, ::MIME"text/plain", img::AbstractImageIndexed) = showim(io, img)
 
 """
 ```

--- a/src/writemime.jl
+++ b/src/writemime.jl
@@ -9,7 +9,7 @@ mimewritable{C<:Colorant}(::MIME"image/png", img::AbstractArray{C}) = sdims(img)
 # This is used for output by IJulia. Really large images can make
 # display very slow, so we shrink big images.  Conversely, tiny images
 # don't show up well, so in such cases we repeat pixels.
-function writemime(io::IO, mime::MIME"image/png", img::AbstractImage; mapi=mapinfo_writemime(img), minpixels=10^4, maxpixels=10^6)
+@compat function Base.show(io::IO, mime::MIME"image/png", img::AbstractImage; mapi=mapinfo_writemime(img), minpixels=10^4, maxpixels=10^6)
     assert2d(img)
     A = data(img)
     nc = ncolorelem(img)
@@ -30,10 +30,12 @@ function writemime(io::IO, mime::MIME"image/png", img::AbstractImage; mapi=mapin
     save(Stream(format"PNG", io), imgcopy)
 end
 
-writemime(stream::IO, mime::MIME"image/png", img::AbstractImageIndexed; kwargs...) = (println(kwargs);
-    writemime(stream, mime, convert(Image, img); kwargs...))
-writemime{C<:Colorant}(stream::IO, mime::MIME"image/png", img::AbstractArray{C}; kwargs...) =
-    writemime(stream, mime, Image(img, spatialorder=["x","y"]); kwargs...)
+@compat function Base.show(stream::IO, mime::MIME"image/png", img::AbstractImageIndexed; kwargs...)
+    @compat show(stream, mime, convert(Image, img); kwargs...)
+end
+@compat function Base.show{C<:Colorant}(stream::IO, mime::MIME"image/png", img::AbstractArray{C}; kwargs...)
+    @compat show(stream, mime, Image(img, spatialorder=["x","y"]); kwargs...)
+end
 
 function mapinfo_writemime(img; maxpixels=10^6)
     if length(img) <= maxpixels

--- a/test/writemime.jl
+++ b/test/writemime.jl
@@ -1,4 +1,4 @@
-facts("Writemime") do
+facts("show (MIME)") do
     workdir = joinpath(tempdir(), "Images")
     if !isdir(workdir)
         mkdir(workdir)
@@ -7,7 +7,7 @@ facts("Writemime") do
         A = U8[0.01 0.99; 0.25 0.75]
         fn = joinpath(workdir, "writemime.png")
         open(fn, "w") do file
-            writemime(file, MIME("image/png"), grayim(A), minpixels=0, maxpixels=typemax(Int))
+            @compat show(file, MIME("image/png"), grayim(A), minpixels=0, maxpixels=typemax(Int))
         end
         b = convert(Image{Gray{U8}}, load(fn))
         @fact data(b) --> A
@@ -16,7 +16,7 @@ facts("Writemime") do
         A = U8[0.01 0.99; 0.25 0.75]
         fn = joinpath(workdir, "writemime.png")
         open(fn, "w") do file
-            writemime(file, MIME("image/png"), grayim(A), minpixels=5, maxpixels=typemax(Int))
+            @compat show(file, MIME("image/png"), grayim(A), minpixels=5, maxpixels=typemax(Int))
         end
         b = convert(Image{Gray{U8}}, load(fn))
         @fact data(b) --> A[[1,1,2,2],[1,1,2,2]]
@@ -26,7 +26,7 @@ facts("Writemime") do
         Ar = restrict(A)
         fn = joinpath(workdir, "writemime.png")
         open(fn, "w") do file
-            writemime(file, MIME("image/png"), grayim(A), minpixels=0, maxpixels=5)
+            @compat show(file, MIME("image/png"), grayim(A), minpixels=0, maxpixels=5)
         end
         b = convert(Image{Gray{U8}}, load(fn))
         @fact data(b) --> convert(Array{U8}, Ar)
@@ -34,7 +34,7 @@ facts("Writemime") do
         abig = grayim(rand(UInt8, 1024, 1023))
         fn = joinpath(workdir, "big.png")
         open(fn, "w") do file
-            writemime(file, MIME("image/png"), abig, maxpixels=10^6)
+            @compat show(file, MIME("image/png"), abig, maxpixels=10^6)
         end
         b = convert(Image{Gray{U8}}, load(fn))
         abigui = convert(Array{UFixed8,2}, data(restrict(abig, (1,2))))


### PR DESCRIPTION
Once we drop 0.4 support, there should be some more internal renaming, but this is fine for now.