### PR TITLE
Fix Bilinear Interpolation

### DIFF
--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -1850,17 +1850,17 @@ function bilinear_interpolation{T}(img::AbstractArray{T, 2}, y::Number, x::Numbe
 
     if x_max == x_min
         if y_max == y_min
-            return topleft
+            return T(topleft)
         end
-        return ((y_max - y) * topleft + (y - y_min) * bottomleft) / (y_max - y_min)
+        return T(((y_max - y) * topleft + (y - y_min) * bottomleft) / (y_max - y_min))
     elseif y_max == y_min
-        return ((x_max - x) * topleft + (x - x_min) * topright) / (x_max - x_min)
+        return T(((x_max - x) * topleft + (x - x_min) * topright) / (x_max - x_min))
     end
 
     r1 = ((x_max - x) * topleft + (x - x_min) * topright) / (x_max - x_min)
     r2 = ((x_max - x) * bottomleft + (x - x_min) * bottomright) / (x_max - x_min)
 
-    ((y_max - y) * r1 + (y - y_min) * r2) / (y_max - y_min)
+    T(((y_max - y) * r1 + (y - y_min) * r2) / (y_max - y_min))
 
 end
 

--- a/test/algorithms.jl
+++ b/test/algorithms.jl
@@ -573,12 +573,12 @@ facts("Algorithms") do
 
     context("Interpolations") do
 
-        img = zeros(5, 5)
+        img = zeros(Float64, 5, 5)
         @fact bilinear_interpolation(img, 4.5, 5.5) --> 0.0
         @fact bilinear_interpolation(img, 4.5, 3.5) --> 0.0
 
         for i in [1.0, 2.0, 5.0, 7.0, 9.0]
-            img = ones(5, 5) * i
+            img = ones(Float64, 5, 5) * i
             @fact (bilinear_interpolation(img, 3.5, 4.5) == i) --> true
             @fact (bilinear_interpolation(img, 3.2, 4) == i) --> true # X_MAX == X_MIN
             @fact (bilinear_interpolation(img, 3.2, 4) == i) --> true # Y_MAX == Y_MIN
@@ -592,7 +592,7 @@ facts("Algorithms") do
             @fact isapprox(bilinear_interpolation(img, 0.5, 0.5), 0.25 * i) --> true
         end
 
-        img = reshape(1:25, 5, 5)
+        img = reshape(1.0:1.0:25.0, 5, 5)
         @fact bilinear_interpolation(img, 1.5, 2) --> 6.5
         @fact bilinear_interpolation(img, 2, 1.5) --> 4.5
         @fact bilinear_interpolation(img, 2, 1) --> 2.0


### PR DESCRIPTION
Was converting pixels of type ```Gray{U8}``` to Gray{Float64}``` on division, causing problems in direction coded LBP.