### PR TITLE
Fix depwarn on 0.6 due to vectorized functions

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -6,5 +6,5 @@ SIUnits
 Zlib
 Graphics 0.1
 FileIO
-Compat 0.8.4
+Compat 0.9.1
 StatsBase   # for histrange

--- a/src/core.jl
+++ b/src/core.jl
@@ -987,7 +987,7 @@ pixelspacing{T}(img::AbstractImage{T}) = @get img "pixelspacing" _pixelspacing(i
 function _pixelspacing(img::AbstractImage)
     if haskey(img, "spacedirections")
         sd = img["spacedirections"]
-        return [maximum(abs(sd[i])) for i = 1:length(sd)]
+        return [maximum(@compat abs.(sd[i])) for i = 1:length(sd)]
     end
     ones(sdims(img))
 end

--- a/src/edge.jl
+++ b/src/edge.jl
@@ -156,7 +156,10 @@ Equivalent to ``sqrt(grad_x.^2 + grad_y.^2)``.
 
 Returns a magnitude image the same size as `grad_x` and `grad_y`.
 """
-magnitude(grad_x::AbstractArray, grad_y::AbstractArray) = hypot(grad_x, grad_y)
+magnitude(grad_x::AbstractArray, grad_y::AbstractArray) =
+    @compat hypot.(grad_x, grad_y)
+magnitude(img1::AbstractImageDirect, img2::AbstractImageDirect) =
+    hypot(img1, img2)
 
 # Phase (angle of steepest gradient ascent), calculated from X and Y gradient images
 """
@@ -381,13 +384,13 @@ function _calc_discrete_offsets(θ, radius, transposed)
     # x and y offset of points at specified radius and angles
     # from each reference position.
 
-    if transposed
+    @compat if transposed
         # θ′ = -π/2 - θ
-        xoffs = [CoordOffset(-x) for x in  radius*sin(angles)]
-        yoffs = [CoordOffset( y) for y in  radius*cos(angles)]
+        xoffs = [CoordOffset(-x) for x in  radius * sin.(angles)]
+        yoffs = [CoordOffset( y) for y in  radius * cos.(angles)]
     else
-        xoffs = [CoordOffset( x) for x in  radius*cos(angles)]
-        yoffs = [CoordOffset(-y) for y in  radius*sin(angles)]
+        xoffs = [CoordOffset( x) for x in  radius * cos.(angles)]
+        yoffs = [CoordOffset(-y) for y in  radius * sin.(angles)]
     end
 
     return θ, xoffs, yoffs

--- a/src/exposure.jl
+++ b/src/exposure.jl
@@ -244,8 +244,8 @@ function _histmatch(img::AbstractArray, oedges::Range, ohist::AbstractArray{Int}
     ocdf = cumsum(ohist)
     norm_ocdf = ocdf / ocdf[end]
     lookup_table = zeros(Int, length(norm_cdf))
-    for I in eachindex(cdf)
-        lookup_table[I] = indmin(abs(norm_ocdf - norm_cdf[I]))
+    @compat for I in eachindex(cdf)
+        lookup_table[I] = indmin(abs.(norm_ocdf .- norm_cdf[I]))
     end
     hist_matched_img = similar(img)
     for I in eachindex(img)

--- a/test/edge.jl
+++ b/test/edge.jl
@@ -116,7 +116,7 @@ facts("Edge") do
     cb_image_rgb = convert(Image{RGB}, cb_image_xy)
     cb_image_rgb2 = convert(Image{RGB{Float64}}, cb_image_xy)
 
-    context("Checkerboard") do
+    @compat context("Checkerboard") do
         for method in ["sobel", "prewitt", "ando3", "ando4", "ando5", "ando4_sep", "ando5_sep"]
             ## Checkerboard array
 
@@ -138,7 +138,8 @@ facts("Edge") do
 
             # Test that orientation is perpendicular to gradient
             aorient = orientation(agx, agy)
-            @fact all((cos(agphase).*cos(aorient) .+ sin(agphase).*sin(aorient) .< EPS) |
+            @fact all((cos.(agphase) .* cos.(aorient) .+
+                       sin.(agphase) .* sin.(aorient) .< EPS) |
                       ((agphase .== 0.0) & (aorient .== 0.0))) --> true
                       # this part is where both are zero because there is no gradient
 
@@ -161,7 +162,8 @@ facts("Edge") do
 
             # Test that orientation is perpendicular to gradient
             orient = orientation(gx, gy)
-            @fact all((cos(gphase).*cos(orient) .+ sin(gphase).*sin(orient) .< EPS) |
+            @fact all((cos.(gphase) .* cos.(orient) .+
+                       sin.(gphase) .* sin.(orient) .< EPS) |
                       ((gphase .== 0.0) & (orient .== 0.0))) --> true
                        # this part is where both are zero because there is no gradient
 
@@ -185,7 +187,8 @@ facts("Edge") do
 
             # Test that orientation is perpendicular to gradient
             orient = orientation(gx, gy)
-            @fact all((cos(gphase).*cos(orient) .+ sin(gphase).*sin(orient) .< EPS) |
+            @fact all((cos.(gphase) .* cos.(orient) .+
+                       sin.(gphase) .* sin.(orient) .< EPS) |
                       ((gphase .== 0.0) & (orient .== 0.0))) --> true
                       # this part is where both are zero because there is no gradient
 
@@ -208,7 +211,8 @@ facts("Edge") do
 
             # Test that orientation is perpendicular to gradient
             orientg = orientation(gxg, gyg)
-            @fact all((cos(gphaseg).*cos(orientg) .+ sin(gphaseg).*sin(orientg) .< EPS) |
+            @fact all((cos.(gphaseg) .* cos.(orientg) .+
+                       sin.(gphaseg) .* sin.(orientg) .< EPS) |
                       ((gphaseg .== 0.0) & (orientg .== 0.0))) --> true
                       # this part is where both are zero because there is no gradient
 
@@ -231,7 +235,8 @@ facts("Edge") do
 
             # Test that orientation is perpendicular to gradient
             orient_rgb = orientation(gx_rgb, gy_rgb)
-            @fact all((cos(gphase_rgb).*cos(orient_rgb) .+ sin(gphase_rgb).*sin(orient_rgb) .< EPS) |
+            @fact all((cos.(gphase_rgb) .* cos.(orient_rgb) .+
+                       sin.(gphase_rgb) .* sin.(orient_rgb) .< EPS) |
                       ((gphase_rgb .== 0.0) & (orient_rgb .== 0.0))) --> true
                       # this part is where both are zero because there is no gradient
 
@@ -254,13 +259,14 @@ facts("Edge") do
 
             # Test that orientation is perpendicular to gradient
             orient_rgb = orientation(gx_rgb, gy_rgb)
-            @fact all((cos(gphase_rgb).*cos(orient_rgb) .+ sin(gphase_rgb).*sin(orient_rgb) .< EPS) |
+            @fact all((cos.(gphase_rgb) .* cos.(orient_rgb) .+
+                       sin.(gphase_rgb) .* sin.(orient_rgb) .< EPS) |
                       ((gphase_rgb .== 0.0) & (orient_rgb .== 0.0))) --> true
                       # this part is where both are zero because there is no gradient
         end
     end
 
-    context("Diagonals") do
+    @compat context("Diagonals") do
         # Create an image with white along diagonals -2:2 and black elsewhere
         m = zeros(UInt8, 20,20)
         for i = -2:2; m[diagind(m,i)] = 0xff; end
@@ -288,7 +294,8 @@ facts("Edge") do
 
             # Test that orientation is perpendicular to gradient
             aorient = orientation(agx, agy)
-            @fact all((cos(agphase).*cos(aorient) .+ sin(agphase).*sin(aorient) .< EPS) |
+            @fact all((cos.(agphase) .* cos.(aorient) .+
+                       sin.(agphase) .* sin.(aorient) .< EPS) |
                       ((agphase .== 0.0) & (aorient .== 0.0))) --> true
                       # this part is where both are zero because there is no gradient
 
@@ -310,7 +317,8 @@ facts("Edge") do
 
             # Test that orientation is perpendicular to gradient
             orient = orientation(gx, gy)
-            @fact all((cos(gphase).*cos(orient) .+ sin(gphase).*sin(orient) .< EPS) |
+            @fact all((cos.(gphase) .* cos.(orient) .+
+                       sin.(gphase) .* sin.(orient) .< EPS) |
                       ((gphase .== 0.0) & (orient .== 0.0))) --> true
                       # this part is where both are zero because there is no gradient
 
@@ -332,7 +340,8 @@ facts("Edge") do
 
             # Test that orientation is perpendicular to gradient
             orient = orientation(gx, gy)
-            @fact all((cos(gphase).*cos(orient) .+ sin(gphase).*sin(orient) .< EPS) |
+            @fact all((cos.(gphase) .* cos.(orient) .+
+                       sin.(gphase) .* sin.(orient) .< EPS) |
                       ((gphase .== 0.0) & (orient .== 0.0))) --> true
                       # this part is where both are zero because there is no gradient
         end

--- a/test/map.jl
+++ b/test/map.jl
@@ -203,7 +203,7 @@ facts("Map") do
     context("ScaleAutoMinMax") do
         mapi = ScaleAutoMinMax()
         A = [100,550,1000]
-        @chk map(mapi, A) ufixed8([0.0,0.5,1.0])
+        @chk map(mapi, A) @compat ufixed8.([0.0,0.5,1.0])
         mapi = ScaleAutoMinMax(RGB24)
         @chk map(mapi, A) RGB24[0x00000000, 0x00808080, 0x00ffffff]
 


### PR DESCRIPTION
All tests passes locally. The WIP is because there's [one test](https://github.com/timholy/Images.jl/compare/yyc/0.6-dep?expand=1#diff-efda1537dfa19ffae4976ef9a6bf697cL33) that I need to change. The test starts to fail on 0.4 half way when I'm making the changes and I have no idea why it's happening.