### PR TITLE
Rework interface to blob_LoG and reimplement findlocalextrema

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -95,7 +95,7 @@ Key changes (of which many are breaking):
 - Many deprecation warnings were designed to help users of the current
   Images package transition to the new framework.
 
-Other changes:
+Other changes (all of which are breaking):
 
 - The gradient components returned by `imgradients` match the
   dimensions of the input; in `g1, g2, ... = imgradients(img,
@@ -117,6 +117,13 @@ Other changes:
 
 - The old `extrema_filter` discards the edges of the image, whereas
   the new one (based on `mapwindow`) returns an array of the same size as the input.
+
+- The output of `blob_LoG` is now a `Vector{BlobLoG}`, a new exported
+  immutable, rather than the old tuple format.
+
+- `findlocalextrema` now returns a `Vector{CartesianIndex{N}}` rather
+  than a `Vector{NTuple{N,Int}}`. This makes it ready for use in efficient
+  indexing.
 
 # Older versions
 

--- a/src/Images.jl
+++ b/src/Images.jl
@@ -64,6 +64,7 @@ include("distances.jl")
 include("deprecated.jl")
 
 export # types
+    BlobLoG,
     ColorizedArray,
 
     # macros

--- a/test/algorithms.jl
+++ b/test/algorithms.jl
@@ -1,0 +1,39 @@
+using Images
+using Base.Test
+
+@testset "Algorithms" begin
+    @testset "Features" begin
+        A = zeros(Int, 9, 9); A[5, 5] = 1
+        blobs = blob_LoG(A, 2.0.^[0.5,0,1])
+        @test length(blobs) == 1
+        blob = blobs[1]
+        @test blob.amplitude ≈ 0.3183098861837907
+        @test blob.σ === 1.0
+        @test blob.location == CartesianIndex((5,5))
+        @test blob_LoG(A, [1.0]) == blobs
+        @test blob_LoG(A, [1.0], (true, false, false)) == blobs
+        @test isempty(blob_LoG(A, [1.0], false))
+        A = zeros(Int, 9, 9); A[1, 5] = 1
+        blobs = blob_LoG(A, 2.0.^[0,0.5,1])
+        A = zeros(Int, 9, 9); A[1,5] = 1
+        blobs = blob_LoG(A, 2.0.^[0.5,0,1])
+        @test all(b.amplitude < 1e-16 for b in blobs)
+        blobs = filter(b->b.amplitude > 0.1, blob_LoG(A, 2.0.^[0.5,0,1], true))
+        @test length(blobs) == 1
+        @test blobs[1].location == CartesianIndex((1,5))
+        @test filter(b->b.amplitude > 0.1, blob_LoG(A, 2.0.^[0.5,0,1], (true, true, false))) == blobs
+        @test isempty(blob_LoG(A, 2.0.^[0,1], (false, true, false)))
+        blobs = blob_LoG(A, 2.0.^[0,0.5,1], (true, false, true))
+        @test all(b.amplitude < 1e-16 for b in blobs)
+        A = zeros(Int, 9, 9); A[[1:2;5],5]=1
+        @test findlocalmaxima(A) == [CartesianIndex((5,5))]
+        @test findlocalmaxima(A,2) == [CartesianIndex((1,5)),CartesianIndex((2,5)),CartesianIndex((5,5))]
+        @test findlocalmaxima(A,2,false) == [CartesianIndex((2,5)),CartesianIndex((5,5))]
+        A = zeros(Int, 9, 9, 9); A[[1:2;5],5,5]=1
+        @test findlocalmaxima(A) == [CartesianIndex((5,5,5))]
+        @test findlocalmaxima(A,2) == [CartesianIndex((1,5,5)),CartesianIndex((2,5,5)),CartesianIndex((5,5,5))]
+        @test findlocalmaxima(A,2,false) == [CartesianIndex((2,5,5)),CartesianIndex((5,5,5))]
+    end
+end
+
+nothing

--- a/test/old/algorithms.jl
+++ b/test/old/algorithms.jl
@@ -213,20 +213,6 @@ facts("Algorithms") do
         @fact img2 --> roughly(A) "test D74cjO"
     end
 
-    context("Features") do
-        A = zeros(Int, 9, 9); A[5, 5] = 1
-        @fact all(x->x<eps(),[blob_LoG(A, 2.0.^[0.5,0,1])[1]...] - [0.3183098861837907,sqrt(2),5,5]) --> true "test IIHdVc"
-        @fact all(x->x<eps(),[blob_LoG(A, [1])[1]...] - [0.3183098861837907,sqrt(2),5,5]) --> true "test CMOJKr"
-        A = zeros(Int, 9, 9); A[[1:2;5],5]=1
-        @fact findlocalmaxima(A) --> [(5,5)] "test xyncRi"
-        @fact findlocalmaxima(A,2) --> [(1,5),(2,5),(5,5)] "test vRMsHj"
-        @fact findlocalmaxima(A,2,false) --> [(2,5),(5,5)] "test NpwSel"
-        A = zeros(Int, 9, 9, 9); A[[1:2;5],5,5]=1
-        @fact findlocalmaxima(A) --> [(5,5,5)] "test lSv2tA"
-        @fact findlocalmaxima(A,2) --> [(1,5,5),(2,5,5),(5,5,5)] "test 4jrt8N"
-        @fact findlocalmaxima(A,2,false) --> [(2,5,5),(5,5,5)] "test 2awiPo"
-    end
-
     context("Restriction") do
         imgcol = Images.colorim(rand(3,5,6))
         A = reshape([convert(UInt16, i) for i = 1:60], 4, 5, 3)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,4 @@
 include("arrays.jl")
+include("algorithms.jl")
 
 include("old/runtests.jl")


### PR DESCRIPTION
At the moment, julia-0.6 is picky about what can and can't be in a `@generated` function, and `findlocalextrema` seems not to meet these requirements. As a consequence our tests have been failing on `nightly` for some time (e.g., https://travis-ci.org/timholy/Images.jl/builds/168159481).

I've gotten rid of a lot of the `@generated` functions in the `images-next` branch, and this PR (against that branch, not master) removes the last one, `findlocalextrema`. As a bonus, it's about 30-fold faster in my hands (I'm not quite sure why, the old version looked mostly OK, though if I had to guess the `in(d,region) ? x : y` test was to blame).

I also restructured `blob_LoG` according to the discussion in #546, and even made the output its own type. This is obviously a breaking change, but since the 0.6 of release of Images will contain several other (unavoidable) breaking changes I don't think this one is exceptional. Fundamentally it's quite hard to have a good deprecation strategy for situations in which the output changes. We could easily add a `getindex(::BlobLog, i) = error("the output of blob_LoG has changed, see the help and NEWS.md")`, but I'm uncertain whether that would actually be better than the `MethodError`.

CC @bjarthur 