### PR TITLE
Fix 0.6 depwarns

### DIFF
--- a/src/Images.jl
+++ b/src/Images.jl
@@ -2,7 +2,11 @@ __precompile__(true)
 
 module Images
 
-import Base.take
+if VERSION >= v"0.6.0-dev.1024"
+    import Base.Iterators.take
+else
+    import Base.take
+end
 import Base.Order: Ordering, ForwardOrdering, ReverseOrdering
 import Base: ==, .==, +, -, *, /, .+, .-, .*, ./, .^, .<, .>
 import Base: abs, atan2, clamp, convert, copy, copy!, ctranspose, delete!, done,

--- a/src/connected.jl
+++ b/src/connected.jl
@@ -89,7 +89,7 @@ function label_components!(Albl::AbstractArray{Int}, A::Array, region::Union{Dim
         f! = _label_components_cache[key]
     end
     sets = DisjointMinSets()
-    f!(Albl, sets, A, bkg)
+    eval(:($f!($Albl, $sets, $A, $bkg)))
     # Now parse sets to find the labels
     newlabel = minlabel(sets)
     for i = 1:length(A)

--- a/test/algorithms.jl
+++ b/test/algorithms.jl
@@ -8,27 +8,27 @@ facts("Algorithms") do
     approx_equal(ar, v) = @compat all(abs.(ar.-v) .< sqrt(eps(v)))
     approx_equal(ar::Images.AbstractImage, v) = approx_equal(Images.data(ar), v)
 
-	context("Flip dimensions") do
-		A = UInt8[200 150; 50 1]
-		img_x = grayim(A)
-		img_y = permutedims(img_x, [2, 1])
+    context("Flip dimensions") do
+        A = UInt8[200 150; 50 1]
+        img_x = grayim(A)
+        img_y = permutedims(img_x, [2, 1])
 
-		@fact raw(flipdim(img_x, "x")) --> raw(flipdim(img_x, 1))
-		@fact raw(flipdim(img_x, "x")) --> flipdim(A, 1)
-		@fact raw(flipdim(img_y, "x")) --> raw(flipdim(img_y, 2))
-		@fact raw(flipdim(img_y, "x")) --> flipdim(A', 2)
+        @fact raw(flipdim(img_x, "x")) --> raw(flipdim(img_x, 1))
+        @fact raw(flipdim(img_x, "x")) --> flipdim(A, 1)
+        @fact raw(flipdim(img_y, "x")) --> raw(flipdim(img_y, 2))
+        @fact raw(flipdim(img_y, "x")) --> flipdim(A', 2)
 
-		@fact raw(flipdim(img_x, "y")) --> raw(flipdim(img_x, 2))
-		@fact raw(flipdim(img_x, "y")) --> flipdim(A, 2)
-		@fact raw(flipdim(img_y, "y")) --> raw(flipdim(img_y, 1))
-		@fact raw(flipdim(img_y, "y")) --> flipdim(A', 1)
+        @fact raw(flipdim(img_x, "y")) --> raw(flipdim(img_x, 2))
+        @fact raw(flipdim(img_x, "y")) --> flipdim(A, 2)
+        @fact raw(flipdim(img_y, "y")) --> raw(flipdim(img_y, 1))
+        @fact raw(flipdim(img_y, "y")) --> flipdim(A', 1)
 
-		@fact raw(flipx(img_x)) --> raw(flipdim(img_x, "x"))
-		@fact raw(flipx(img_y)) --> raw(flipdim(img_y, "x"))
+        @fact raw(flipx(img_x)) --> raw(flipdim(img_x, "x"))
+        @fact raw(flipx(img_y)) --> raw(flipdim(img_y, "x"))
 
-		@fact raw(flipy(img_x)) --> raw(flipdim(img_x, "y"))
-		@fact raw(flipy(img_y)) --> raw(flipdim(img_y, "y"))
-	end
+        @fact raw(flipy(img_x)) --> raw(flipdim(img_x, "y"))
+        @fact raw(flipy(img_y)) --> raw(flipdim(img_y, "y"))
+    end
 
     context("Arithmetic") do
         img = convert(Images.Image, zeros(3,3))

--- a/test/edge.jl
+++ b/test/edge.jl
@@ -1,6 +1,14 @@
-using Images, FactCheck, Base.Test, Colors
+module TestImagesEdge
+using Images, FactCheck, Base.Test, Colors, Compat, Graphics
 
 global checkboard
+
+if VERSION < v"0.5.0"
+    # Overwrite `Base.all` to work around poor inference on 0.4
+    function all(ary)
+        Base.all(convert(Array{Bool}, ary))
+    end
+end
 
 facts("Edge") do
 
@@ -138,9 +146,9 @@ facts("Edge") do
 
             # Test that orientation is perpendicular to gradient
             aorient = orientation(agx, agy)
-            @fact all((cos.(agphase) .* cos.(aorient) .+
-                       sin.(agphase) .* sin.(aorient) .< EPS) |
-                      ((agphase .== 0.0) & (aorient .== 0.0))) --> true
+            @fact all((|).(cos.(agphase) .* cos.(aorient) .+
+                           sin.(agphase) .* sin.(aorient) .< EPS,
+                           (&).(agphase .== 0.0, aorient .== 0.0))) --> true
                       # this part is where both are zero because there is no gradient
 
             ## Checkerboard Image with row major order
@@ -162,9 +170,9 @@ facts("Edge") do
 
             # Test that orientation is perpendicular to gradient
             orient = orientation(gx, gy)
-            @fact all((cos.(gphase) .* cos.(orient) .+
-                       sin.(gphase) .* sin.(orient) .< EPS) |
-                      ((gphase .== 0.0) & (orient .== 0.0))) --> true
+            @fact all((|).(cos.(gphase) .* cos.(orient) .+
+                           sin.(gphase) .* sin.(orient) .< EPS,
+                           (&).(gphase .== 0.0, orient .== 0.0))) --> true
                        # this part is where both are zero because there is no gradient
 
             ## Checkerboard Image with column-major order
@@ -187,9 +195,9 @@ facts("Edge") do
 
             # Test that orientation is perpendicular to gradient
             orient = orientation(gx, gy)
-            @fact all((cos.(gphase) .* cos.(orient) .+
-                       sin.(gphase) .* sin.(orient) .< EPS) |
-                      ((gphase .== 0.0) & (orient .== 0.0))) --> true
+            @fact all((|).(cos.(gphase) .* cos.(orient) .+
+                           sin.(gphase) .* sin.(orient) .< EPS,
+                           (&).(gphase .== 0.0, orient .== 0.0))) --> true
                       # this part is where both are zero because there is no gradient
 
             ## Checkerboard Image with Gray pixels
@@ -211,9 +219,9 @@ facts("Edge") do
 
             # Test that orientation is perpendicular to gradient
             orientg = orientation(gxg, gyg)
-            @fact all((cos.(gphaseg) .* cos.(orientg) .+
-                       sin.(gphaseg) .* sin.(orientg) .< EPS) |
-                      ((gphaseg .== 0.0) & (orientg .== 0.0))) --> true
+            @fact all((|).(cos.(gphaseg) .* cos.(orientg) .+
+                           sin.(gphaseg) .* sin.(orientg) .< EPS,
+                           (&).(gphaseg .== 0.0, orientg .== 0.0))) --> true
                       # this part is where both are zero because there is no gradient
 
             ## Checkerboard Image with RBG pixels
@@ -235,9 +243,9 @@ facts("Edge") do
 
             # Test that orientation is perpendicular to gradient
             orient_rgb = orientation(gx_rgb, gy_rgb)
-            @fact all((cos.(gphase_rgb) .* cos.(orient_rgb) .+
-                       sin.(gphase_rgb) .* sin.(orient_rgb) .< EPS) |
-                      ((gphase_rgb .== 0.0) & (orient_rgb .== 0.0))) --> true
+            @fact all((|).(cos.(gphase_rgb) .* cos.(orient_rgb) .+
+                           sin.(gphase_rgb) .* sin.(orient_rgb) .< EPS,
+                           (&).(gphase_rgb .== 0.0, orient_rgb .== 0.0))) --> true
                       # this part is where both are zero because there is no gradient
 
             ## Checkerboard Image with RBG{Float64} pixels
@@ -259,9 +267,9 @@ facts("Edge") do
 
             # Test that orientation is perpendicular to gradient
             orient_rgb = orientation(gx_rgb, gy_rgb)
-            @fact all((cos.(gphase_rgb) .* cos.(orient_rgb) .+
-                       sin.(gphase_rgb) .* sin.(orient_rgb) .< EPS) |
-                      ((gphase_rgb .== 0.0) & (orient_rgb .== 0.0))) --> true
+            @fact all((|).(cos.(gphase_rgb) .* cos.(orient_rgb) .+
+                           sin.(gphase_rgb) .* sin.(orient_rgb) .< EPS,
+                           (&).(gphase_rgb .== 0.0, orient_rgb .== 0.0))) --> true
                       # this part is where both are zero because there is no gradient
         end
     end
@@ -294,9 +302,9 @@ facts("Edge") do
 
             # Test that orientation is perpendicular to gradient
             aorient = orientation(agx, agy)
-            @fact all((cos.(agphase) .* cos.(aorient) .+
-                       sin.(agphase) .* sin.(aorient) .< EPS) |
-                      ((agphase .== 0.0) & (aorient .== 0.0))) --> true
+            @fact all((|).(cos.(agphase) .* cos.(aorient) .+
+                           sin.(agphase) .* sin.(aorient) .< EPS,
+                           (&).(agphase .== 0.0, aorient .== 0.0))) --> true
                       # this part is where both are zero because there is no gradient
 
             ## Diagonal Image, row-major order
@@ -317,9 +325,9 @@ facts("Edge") do
 
             # Test that orientation is perpendicular to gradient
             orient = orientation(gx, gy)
-            @fact all((cos.(gphase) .* cos.(orient) .+
-                       sin.(gphase) .* sin.(orient) .< EPS) |
-                      ((gphase .== 0.0) & (orient .== 0.0))) --> true
+            @fact all((|).(cos.(gphase) .* cos.(orient) .+
+                           sin.(gphase) .* sin.(orient) .< EPS,
+                           (&).(gphase .== 0.0, orient .== 0.0))) --> true
                       # this part is where both are zero because there is no gradient
 
             ## Diagonal Image, column-major order
@@ -340,9 +348,9 @@ facts("Edge") do
 
             # Test that orientation is perpendicular to gradient
             orient = orientation(gx, gy)
-            @fact all((cos.(gphase) .* cos.(orient) .+
-                       sin.(gphase) .* sin.(orient) .< EPS) |
-                      ((gphase .== 0.0) & (orient .== 0.0))) --> true
+            @fact all((|).(cos.(gphase) .* cos.(orient) .+
+                           sin.(gphase) .* sin.(orient) .< EPS,
+                           (&).(gphase .== 0.0, orient .== 0.0))) --> true
                       # this part is where both are zero because there is no gradient
         end
     end
@@ -386,7 +394,7 @@ facts("Edge") do
         transposed = spatialorder(img)[1] == "x"
         horizontal = which == :horizontal
 
-        test_axis1 = transposed $ !horizontal
+        test_axis1 = transposed ⊻ !horizontal
 
         if test_axis1
             @fact all(t[:,[1,2,4,5]] .== 0) --> true
@@ -513,4 +521,5 @@ end
         nms_test_diagonal(m_yx)
     end
 
+end
 end

--- a/test/overlays.jl
+++ b/test/overlays.jl
@@ -41,7 +41,7 @@ facts("Overlay") do
         @fact isa(s, Matrix{RGB{Float32}}) --> true
         @fact size(s) --> (3, 2)
         buf = Images.uint32color(ovr)
-        gray8 = round(UInt8, 255*gray)
+        gray8 = [round(UInt8, 255 * x) for x in gray]
         nogreen = reinterpret(RGB24, [convert(UInt32, g)<<16 | convert(UInt32, g) for g in gray8])
         @fact buf --> nogreen
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ module ImagesTests
 
 using FactCheck, Base.Test, Images, Colors, FixedPointNumbers
 using Graphics
+using Compat
 
 testing_units = Int == Int64
 if testing_units


### PR DESCRIPTION
This fixes all of the test errors and most of the depwarns on master. Passing tests on master requires https://github.com/JuliaIO/FileIO.jl/pull/94 and some depwarns are fixed by https://github.com/JuliaArchive/FactCheck.jl/pull/80

The depwarns that are not fixed are:

* Extending `.+`, `.==` etc

    Might need `@compat` support and might also need to decide what's the expected return type with loop fusion

* `@test_approx_eq`

    It seems to behave differently wrt `NaN`?

* `reduce_dims`

    Might want to go to `Compat.jl`
